### PR TITLE
Improve error handling for the Iterator trait implementations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ use usn_journal_rs::{volume::Volume, journal::UsnJournal};
 let drive_letter = 'C';
 let volume = Volume::from_drive_letter(drive_letter)?;
 let journal = UsnJournal::new(&volume);
-for entry in journal.iter()? {
-    println!("USN entry: {:?}", entry);
+for entry_result in journal.iter()? {
+    match entry_result {
+        Ok(entry) => println!("USN entry: {:?}", entry),
+        Err(e) => eprintln!("Error reading USN entry: {e}"),
+    }
 }
 ```
 
@@ -41,8 +44,11 @@ use usn_journal_rs::{volume::Volume, mft::Mft};
 let drive_letter = 'C';
 let volume = Volume::from_drive_letter(drive_letter)?;
 let mft = Mft::new(&volume);
-for entry in mft.iter() {
-    println!("MFT entry: {:?}", entry);
+for entry_result in mft.iter() {
+    match entry_result {
+        Ok(entry) => println!("MFT entry: {:?}", entry),
+        Err(e) => eprintln!("Error reading MFT entry: {e}"),
+    }
 }
 ```
 

--- a/examples/change_monitor.rs
+++ b/examples/change_monitor.rs
@@ -7,7 +7,7 @@ use usn_journal_rs::{
 
 fn main() {
     if let Err(e) = run() {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {e}");
     }
 }
 
@@ -34,7 +34,7 @@ fn run() -> Result<(), UsnError> {
                 println!("{}", entry.pretty_format(full_path));
             }
             Err(e) => {
-                eprintln!("Error reading USN entry: {}", e);
+                eprintln!("Error reading USN entry: {e}");
                 continue;
             }
         }

--- a/examples/change_monitor.rs
+++ b/examples/change_monitor.rs
@@ -27,9 +27,17 @@ fn run() -> Result<(), UsnError> {
 
     let mut path_resolver = PathResolver::new(&volume);
 
-    for entry in usn_journal.iter_with_options(enum_options)? {
-        let full_path = path_resolver.resolve_path(&entry);
-        println!("{}", entry.pretty_format(full_path));
+    for result in usn_journal.iter_with_options(enum_options)? {
+        match result {
+            Ok(entry) => {
+                let full_path = path_resolver.resolve_path(&entry);
+                println!("{}", entry.pretty_format(full_path));
+            }
+            Err(e) => {
+                eprintln!("Error reading USN entry: {}", e);
+                continue;
+            }
+        }
     }
 
     Ok(())

--- a/examples/enum_mft.rs
+++ b/examples/enum_mft.rs
@@ -12,9 +12,17 @@ fn run() -> Result<(), UsnError> {
     let mft = Mft::new(&volume);
     let mut path_resolver = PathResolver::new_with_cache(&volume);
 
-    for entry in mft.iter() {
-        let full_path = path_resolver.resolve_path(&entry);
-        println!("{}", entry.pretty_format(full_path));
+    for result in mft.iter() {
+        match result {
+            Ok(entry) => {
+                let full_path = path_resolver.resolve_path(&entry);
+                println!("{}", entry.pretty_format(full_path));
+            }
+            Err(e) => {
+                eprintln!("Error reading MFT entry: {}", e);
+                continue;
+            }
+        }
     }
 
     Ok(())

--- a/examples/enum_mft.rs
+++ b/examples/enum_mft.rs
@@ -2,7 +2,7 @@ use usn_journal_rs::{errors::UsnError, mft::Mft, path::PathResolver, volume::Vol
 
 fn main() {
     if let Err(e) = run() {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {e}");
     }
 }
 
@@ -19,7 +19,7 @@ fn run() -> Result<(), UsnError> {
                 println!("{}", entry.pretty_format(full_path));
             }
             Err(e) => {
-                eprintln!("Error reading MFT entry: {}", e);
+                eprintln!("Error reading MFT entry: {e}");
                 continue;
             }
         }

--- a/examples/read_journal.rs
+++ b/examples/read_journal.rs
@@ -2,7 +2,7 @@ use usn_journal_rs::{errors::UsnError, journal::UsnJournal, path::PathResolver, 
 
 fn main() {
     if let Err(e) = run() {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {e}");
     }
 }
 
@@ -20,7 +20,7 @@ fn run() -> Result<(), UsnError> {
                 println!("{}", entry.pretty_format(full_path));
             }
             Err(e) => {
-                eprintln!("Error reading USN entry: {}", e);
+                eprintln!("Error reading USN entry: {e}");
                 // Continue processing other entries
                 continue;
             }

--- a/examples/read_journal.rs
+++ b/examples/read_journal.rs
@@ -13,9 +13,18 @@ fn run() -> Result<(), UsnError> {
 
     let mut path_resolver = PathResolver::new_with_cache(&volume);
 
-    for entry in usn_journal.iter()? {
-        let full_path = path_resolver.resolve_path(&entry);
-        println!("{}", entry.pretty_format(full_path));
+    for result in usn_journal.iter()? {
+        match result {
+            Ok(entry) => {
+                let full_path = path_resolver.resolve_path(&entry);
+                println!("{}", entry.pretty_format(full_path));
+            }
+            Err(e) => {
+                eprintln!("Error reading USN entry: {}", e);
+                // Continue processing other entries
+                continue;
+            }
+        }
     }
 
     Ok(())

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -160,12 +160,12 @@ impl<'a> UsnJournal<'a> {
                     let journal_data = self.query_core()?;
                     Ok(journal_data.into())
                 } else {
-                    warn!("Error querying USN journal: {}", err);
+                    warn!("Error querying USN journal: {err}");
                     Err(err.into())
                 }
             }
             Ok(journal_data) => {
-                debug!("USN journal data: {:#?}", journal_data);
+                debug!("USN journal data: {journal_data:#?}");
                 Ok(journal_data.into())
             }
         }
@@ -308,7 +308,7 @@ impl UsnJournalIter {
                 return Ok(false);
             }
 
-            warn!("Error reading USN data: {}", err);
+            warn!("Error reading USN data: {err}");
             return Err(err);
         }
 
@@ -357,7 +357,7 @@ impl Iterator for UsnJournalIter {
             Ok(Some(record)) => Some(Ok(UsnEntry::new(record))),
             Ok(None) => None,
             Err(err) => {
-                debug!("Error finding next USN entry: {}", err);
+                debug!("Error finding next USN entry: {err}");
                 Some(Err(err.into()))
             }
         }
@@ -643,7 +643,7 @@ mod tests {
             let mut previous_usn = -1i64;
             for result in usn_journal.iter()? {
                 let entry = result?; // Handle the Result<UsnEntry>
-                println!("USN entry: {:?}", entry);
+                println!("USN entry: {entry:?}");
                 // Check if the USN entry is valid
                 assert!(entry.usn >= 0, "USN is not valid");
                 assert!(entry.usn > previous_usn, "USN entries are not in order");

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -96,6 +96,9 @@ impl From<USN_JOURNAL_DATA_V0> for UsnJournalData {
 
 #[derive(Debug, Clone)]
 /// Iterator for enumerating USN journal records on NTFS/ReFS volume.
+///
+/// This iterator yields `Result<UsnEntry, UsnError>` items, allowing applications
+/// to handle individual entry errors without stopping the entire iteration process.
 pub struct UsnJournal<'a> {
     pub(crate) volume: &'a Volume,
 }
@@ -107,6 +110,9 @@ impl<'a> UsnJournal<'a> {
     }
 
     /// Returns an iterator over the USN journal entries.
+    ///
+    /// The iterator yields `Result<UsnEntry, UsnError>` items, allowing callers
+    /// to handle individual entry errors gracefully without stopping iteration.
     pub fn iter(&self) -> UsnResult<UsnJournalIter> {
         let journal_data = self.query(true)?;
         Ok(UsnJournalIter {
@@ -124,6 +130,9 @@ impl<'a> UsnJournal<'a> {
     }
 
     /// Returns an iterator over the USN journal entries with custom enumerate options.
+    ///
+    /// The iterator yields `Result<UsnEntry, UsnError>` items, allowing callers
+    /// to handle individual entry errors gracefully without stopping iteration.
     pub fn iter_with_options(&self, options: EnumOptions) -> UsnResult<UsnJournalIter> {
         let journal_data = self.query(true)?;
         Ok(UsnJournalIter {
@@ -265,6 +274,8 @@ impl<'a> UsnJournal<'a> {
 }
 
 /// Iterate over USN journal entries.
+///
+/// This iterator yields `Result<UsnEntry, UsnError>` items.
 pub struct UsnJournalIter {
     volume_handle: HANDLE,
     journal_id: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,11 @@
 //! let drive_letter = 'C';
 //! let volume = Volume::from_drive_letter(drive_letter).unwrap();
 //! let mft = Mft::new(&volume);
-//! for entry in mft.iter().take(10) {
-//!     println!("MFT entry: {:?}", entry);
+//! for result in mft.iter().take(10) {
+//!     match result {
+//!         Ok(entry) => println!("MFT entry: {:?}", entry),
+//!         Err(e) => eprintln!("Error reading MFT entry: {}", e),
+//!     }
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::uninlined_format_args)]
-
 //! # usn-journal-rs
 //!
 //! A Rust library for manipulating the NTFS/ReFS USN change journal and enumerating the NTFS Master File Table (MFT).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@
 //! let journal = UsnJournal::new(&volume);
 //! for result in journal.iter().unwrap().take(10) {
 //!     match result {
-//!         Ok(entry) => println!("USN entry: {:?}", entry),
-//!         Err(e) => eprintln!("Error reading entry: {}", e),
+//!         Ok(entry) => println!("USN entry: {entry:?}"),
+//!         Err(e) => eprintln!("Error reading entry: {e}"),
 //!     }
 //! }
 //! ```
@@ -34,8 +34,8 @@
 //! let mft = Mft::new(&volume);
 //! for result in mft.iter().take(10) {
 //!     match result {
-//!         Ok(entry) => println!("MFT entry: {:?}", entry),
-//!         Err(e) => eprintln!("Error reading MFT entry: {}", e),
+//!         Ok(entry) => println!("MFT entry: {entry:?}"),
+//!         Err(e) => eprintln!("Error reading MFT entry: {e}"),
 //!     }
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,11 @@
 //! let drive_letter = 'C';
 //! let volume = Volume::from_drive_letter(drive_letter).unwrap();
 //! let journal = UsnJournal::new(&volume);
-//! for entry in journal.iter().unwrap().take(10) {
-//!     println!("USN entry: {:?}", entry);
+//! for result in journal.iter().unwrap().take(10) {
+//!     match result {
+//!         Ok(entry) => println!("USN entry: {:?}", entry),
+//!         Err(e) => eprintln!("Error reading entry: {}", e),
+//!     }
 //! }
 //! ```
 //!
@@ -48,6 +51,13 @@ pub mod journal;
 pub mod mft;
 pub mod path;
 mod privilege;
+
+// Re-export commonly used types
+pub use errors::UsnError;
+
+/// A convenient type alias for Results with UsnError.
+pub type UsnResult<T> = std::result::Result<T, UsnError>;
+
 mod time;
 pub mod volume;
 

--- a/src/mft.rs
+++ b/src/mft.rs
@@ -148,6 +148,24 @@ impl<'a> Mft<'a> {
     }
 }
 
+impl<'a> IntoIterator for Mft<'a> {
+    type Item = MftEntry;
+    type IntoIter = MftIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Mft<'a> {
+    type Item = MftEntry;
+    type IntoIter = MftIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 /// Iterator over MFT entries.
 pub struct MftIter {
     volume_handle: HANDLE,

--- a/src/mft.rs
+++ b/src/mft.rs
@@ -232,7 +232,7 @@ impl Iterator for MftIter {
             Ok(Some(record)) => Some(Ok(MftEntry::new(record))),
             Ok(None) => None,
             Err(err) => {
-                debug!("Error finding next MFT entry: {}", err);
+                debug!("Error finding next MFT entry: {err}");
                 Some(Err(err))
             }
         }
@@ -255,7 +255,7 @@ mod tests {
             let mft = Mft::new(&volume);
             for result in mft.iter() {
                 let entry = result?; // Handle the Result<MftEntry>
-                println!("MFT entry: {:?}", entry);
+                println!("MFT entry: {entry:?}");
                 // Check if the Mft entry is valid
                 assert!(entry.usn >= 0, "USN is not valid");
                 assert!(entry.fid > 0, "File ID is not valid");

--- a/src/mft.rs
+++ b/src/mft.rs
@@ -123,6 +123,9 @@ impl<'a> Mft<'a> {
     }
 
     /// Returns an iterator over the MFT entries.
+    ///
+    /// The iterator yields `Result<MftEntry, UsnError>` items, allowing callers
+    /// to handle individual entry errors gracefully without stopping iteration.
     pub fn iter(&self) -> MftIter {
         MftIter {
             volume_handle: self.volume.handle,
@@ -136,6 +139,9 @@ impl<'a> Mft<'a> {
     }
 
     /// Returns an iterator over the MFT entries with custom enumerate options.
+    ///
+    /// The iterator yields `Result<MftEntry, UsnError>` items, allowing callers
+    /// to handle individual entry errors gracefully without stopping iteration.
     pub fn iter_with_options(&self, options: EnumOptions) -> MftIter {
         MftIter {
             volume_handle: self.volume.handle,
@@ -150,6 +156,9 @@ impl<'a> Mft<'a> {
 }
 
 /// Iterator over MFT entries.
+///
+/// This iterator yields `Result<MftEntry, UsnError>` items, allowing applications
+/// to handle individual entry errors without stopping the entire iteration process.
 pub struct MftIter {
     volume_handle: HANDLE,
     low_usn: Usn,

--- a/src/path.rs
+++ b/src/path.rs
@@ -271,7 +271,7 @@ fn file_id_to_path(volume: &Volume, file_id: u64) -> windows::core::Result<PathB
             drive_letter
         };
 
-        full_path.push(format!("{}:\\", drive_letter));
+        full_path.push(format!("{drive_letter}:\\"));
     } else if let Some(mount_point) = &volume.mount_point {
         full_path.push(mount_point);
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,9 +11,9 @@ pub const VHD_EXT: &str = "vhdx";
 pub fn get_workspace_root() -> Result<PathBuf, UsnError> {
     let workspace_root = std::env::var("CARGO_WORKSPACE_DIR")
         .or_else(|_| std::env::var("CARGO_MANIFEST_DIR"))
-        .map_err(|e| UsnError::OtherError(format!("Failed to get workspace root: {}", e)))?;
+        .map_err(|e| UsnError::OtherError(format!("Failed to get workspace root: {e}")))?;
 
-    println!("Current workspace root: {}", workspace_root);
+    println!("Current workspace root: {workspace_root}");
 
     Ok(PathBuf::from(workspace_root))
 }
@@ -30,8 +30,8 @@ pub fn setup() -> Result<(PathBuf, Uuid), UsnError> {
     let uuid = Uuid::new_v4();
     let mount_point = workspace_root
         .join("target")
-        .join(format!("{}-{}", VHD_MOUNT_POINT_BASE, uuid));
-    let vhd_name = format!("{}-{}.{}", VHD_NAME_BASE_NAME, uuid, VHD_EXT);
+        .join(format!("{VHD_MOUNT_POINT_BASE}-{uuid}"));
+    let vhd_name = format!("{VHD_NAME_BASE_NAME}-{uuid}.{VHD_EXT}");
     let vhd_path = workspace_root.join("target").join(vhd_name);
     println!("mount point: {}", mount_point.display());
     println!("vhd path: {}", vhd_path.display());
@@ -94,8 +94,8 @@ pub fn teardown(uuid: Uuid) -> Result<(), UsnError> {
 
     let mount_point = workspace_root
         .join("target")
-        .join(format!("{}-{}", VHD_MOUNT_POINT_BASE, uuid));
-    let vhd_name = format!("{}-{}.{}", VHD_NAME_BASE_NAME, uuid, VHD_EXT);
+        .join(format!("{VHD_MOUNT_POINT_BASE}-{uuid}"));
+    let vhd_name = format!("{VHD_NAME_BASE_NAME}-{uuid}.{VHD_EXT}");
     let vhd_path = workspace_root.join("target").join(vhd_name);
     println!("mount point: {}", mount_point.display());
     println!("vhd path: {}", vhd_path.display());

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -54,7 +54,7 @@ fn get_volume_handle_from_drive_letter(drive_letter: char) -> Result<HANDLE, Usn
     // To obtain a handle to a volume for use with update sequence number (USN) change journal operations,
     // call the CreateFile function with the lpFileName parameter set to a string of the following form: \\.\X:
     // Note that X is the letter that identifies the drive on which the NTFS volume appears.
-    let volume_root = format!(r"\\.\{}:", drive_letter);
+    let volume_root = format!(r"\\.\{drive_letter}:");
 
     match unsafe {
         CreateFileW(
@@ -86,10 +86,7 @@ fn get_volume_handle_from_mount_point(mount_point: &Path) -> Result<HANDLE, UsnE
     if let Err(err) =
         unsafe { GetVolumeNameForVolumeMountPointW(&HSTRING::from(&mount_path), &mut volume_name) }
     {
-        warn!(
-            "GetVolumeNameForVolumeMountPointW failed, mount_point={}, error={:?}",
-            mount_path, err
-        );
+        warn!("GetVolumeNameForVolumeMountPointW failed, mount_point={mount_path}, error={err:?}");
         return Err(err.into());
     }
 
@@ -103,11 +100,11 @@ fn get_volume_handle_from_mount_point(mount_point: &Path) -> Result<HANDLE, UsnE
     ))?;
     let volume_guid = String::from_utf16_lossy(name_data);
 
-    debug!("Volume GUID: {}", volume_guid);
+    debug!("Volume GUID: {volume_guid}");
 
     // IMPORTANT: Remove the trailing backslash for CreateFileW
     let volume_path = volume_guid.trim_end_matches('\\').to_string();
-    debug!("Using volume path: {}", volume_path);
+    debug!("Using volume path: {volume_path}");
 
     let volume_handle = unsafe {
         CreateFileW(
@@ -153,7 +150,7 @@ mod tests {
     fn test_get_volume_handle_from_invalid_drive_letter() {
         let drive_letter = 'W'; // Assuming W is not a valid drive letter
         let result = Volume::from_drive_letter(drive_letter);
-        eprintln!("Result: {:?}", result);
+        eprintln!("Result: {result:?}");
         assert!(
             result.is_err(),
             "Should return an error for invalid drive letter"
@@ -170,7 +167,7 @@ mod tests {
     fn test_get_volume_handle_from_invalid_mount_point() {
         let mount_point = r"C:\invalid\mount\point";
         let result = Volume::from_mount_point(mount_point.as_ref());
-        eprintln!("Result: {:?}", result);
+        eprintln!("Result: {result:?}");
         assert!(
             result.is_err(),
             "Should return an error for invalid mount point"


### PR DESCRIPTION
This pull request introduces enhancements to error handling and type consistency across the `usn-journal-rs` library. The changes primarily focus on updating iterators to yield `Result` types, enabling more robust error handling during iteration, and introducing a unified `UsnResult` type alias for standardizing error handling. Additionally, it improves logging and formatting for error messages.