### PR TITLE
Improve API ergonomics, consistency, and test coverage (0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,26 +44,59 @@ and idiomatic Rust refactoring. **Breaking changes throughout** — see the
 - `JournalIterOptions::builder()`, `MftIterOptions::builder()`,
   `RawMftScanOptions::builder()`, and `RawMftChunkPlanOptions::builder()`.
 - `RawMft::parallel()` builder-style facade for ordered parallel chunk scans.
-- `PathResolver::new(v).with_lru_cache(n).with_in_memory_tree(&raw_mft)?`
-  fluent builder API.
+- `PathResolver::new(v).with_directory_cache(n)` for tuning (or disabling, with
+  `0`) the live resolver's LRU directory cache.
 - `usn_journal_rs::prelude` for common application imports.
-- `InMemoryDirTree::from_raw_mft` for O(1) path resolution without per-lookup
-  syscalls.
+- The prelude now also re-exports the entry types (`UsnEntry`, `MftEntry`,
+  `RawMftEntry`) and the option builders (`JournalIterOptions`, `MftIterOptions`,
+  `RawMftScanOptions`, `UsnRecordVersion`).
+- `RawMft::path_resolver()` → `RawMftPathResolver` for snapshot-local O(1) path
+  reconstruction without per-lookup syscalls.
+- `Volume::journal()`, `Volume::mft()`, `Volume::raw_mft()`, and
+  `Volume::path_resolver()` convenience accessors for discovering the API from a
+  `Volume` (e.g. `volume.journal().try_iter()?`).
 - USN v3 / 128-bit file ID support for `UsnJournal`, `Mft`, and `PathResolver`.
 - `UsnError::NotElevated`, `UsnError::UnsupportedFilesystem(String)`,
   `UsnError::BufferTooSmall { needed, got }`, precise USN parser error
   variants, and offset-aware raw-MFT parse diagnostics.
+- `UsnError::JournalNotActive` plus `UsnJournal::query_or_create()` — explicit
+  "query, creating the journal only if it is missing" semantics.
+- `UsnReason::ALL` — a strongly-typed full 32-bit catch-all reason mask that also
+  matches reason bits newer than this crate (unlike bitflags' `UsnReason::all()`).
+- Named predicate methods on `UsnReason` (`is_file_create`, `is_file_delete`,
+  `is_rename`, `is_close`, `is_data_change`) and on `FileAttributes`
+  (`is_directory`, `is_read_only`, `is_hidden`, `is_system`, `is_archive`,
+  `is_reparse_point`, `is_compressed`, `is_encrypted`, `is_sparse`, `is_offline`,
+  `is_temporary`) for readable change/attribute classification.
+- `UsnEntry` and `MftEntry` gained matching attribute convenience methods
+  (`is_read_only`, `is_system`, `is_archive`, `is_reparse_point`, `is_compressed`,
+  `is_encrypted`, `is_sparse`) alongside the existing `is_dir` / `is_hidden`.
+- `Usn::ZERO` constant for the conventional scan-start cursor.
+- `Filetime::UNIX_EPOCH` constant, `Filetime::is_zero()`,
+  `Filetime::to_unix_millis()`, and `Filetime::from_unix_seconds()`
+  (the missing inverse of `to_unix_seconds`).
+- `Fid::from_parts(record_number, sequence)` — construct a standard NTFS file
+  reference from its parts (inverse of `record_number()` / `sequence()`).
+- `Usn::is_zero()`, `Usn::saturating_add(i64)`, and `Usn::checked_add(i64)`.
+- `fmt::LowerHex` / `fmt::UpperHex` for `Fid` so `{:x}` / `{:X}` / `{:#x}` compose.
+- `Display` for `UsnJournalData` (compact one-line summary for logging).
 - `Display` impl on `UsnEntry` and `MftEntry` (compact one-line format).
+- `Display` impl on `RawMftEntry` (compact one-line format), for parity with the
+  journal and FSCTL-based MFT entries.
+- Runnable doc examples on `Fid::from_parts`, `Filetime::from_unix_seconds`, and
+  `Volume::from_drive_letter`.
 - Benchmarks: `benches/journal.rs`, `benches/path_resolver.rs`.
-- Integration tests: `tests/in_memory_tree.rs`,
-  `tests/path_resolver_consistency.rs`, `tests/refs_unsupported.rs`,
-  `tests/filetime_roundtrip.rs`.
+- Integration tests: `tests/journal_query.rs` (query / query_or_create
+  semantics), `tests/volume_accessors.rs` (Volume accessor equivalence + MFT
+  USN-range edge cases), `tests/path_resolver_consistency.rs`,
+  `tests/raw_mft_mft_consistency.rs`, `tests/refs_unsupported.rs`,
+  `tests/refs_v3_ids.rs`, and `tests/filetime_roundtrip.rs`.
 
 ### Changed
 
 - `Volume` fields are now private; use the public accessor methods.
 - `PathResolver::new` now enables the default LRU directory cache automatically;
-  call `.without_lru_cache()` for fully uncached syscall resolution.
+  call `.with_directory_cache(0)` for fully uncached syscall resolution.
 - `RawMftEntry` timestamps are `Filetime` instead of external date/time types.
 - `UsnEntry::time` is `Filetime` instead of `std::time::SystemTime`.
 - `RawMftIterOptions` renamed to `RawMftScanOptions`, with structured
@@ -87,20 +120,41 @@ and idiomatic Rust refactoring. **Breaking changes throughout** — see the
   (`mod.rs`, `journal.rs`, `iter.rs`, `entry.rs`, `reason.rs`, `options.rs`,
   `data.rs`, `defaults.rs`).
 - `src/record.rs` renamed to `src/usn_record.rs`.
-- Raw `$MFT` on-disk parser modules moved under `src/raw_mft/ondisk/`, and
-  the old mixed `builder_common` helper was split into focused attribute
-  dispatch, attribute capture, and file-name selection modules.
+- Raw `$MFT` on-disk parser modules live under `src/raw_mft/layout/`, and entry
+  construction was split into focused attribute dispatch, capture, and file-name
+  selection modules under `src/raw_mft/entry_build/`.
 - Cargo profile cleanup: removed bogus `[profile.test]` flags; added
   `[profile.bench] lto = "thin"`.
+- `UsnJournal::query` no longer takes a `create_if_not_active: bool`. It now
+  queries only and returns `UsnError::JournalNotActive` when the volume has no
+  journal; use the new `UsnJournal::query_or_create()` to create on demand.
+- `PathResolver::resolve_path` now takes `&self` instead of `&mut self`
+  (directory cache and scratch buffer use interior mutability), matching
+  `RawMftPathResolver::resolve_path`. A single resolver can be shared across an
+  iteration loop without a `mut` binding.
+- `UsnReason`, `FileAttributes`, and `UsnSourceInfo` now share one `Display`
+  implementation. An empty `UsnReason` renders as `NONE` (previously `UNKNOWN`),
+  and a value with only unknown bits renders as hex (e.g. `0x8`), consistent
+  with the other two bitflag types.
+- `UsnError::InvalidMountPointError` renamed to `UsnError::InvalidMountPoint`
+  (the redundant `Error` suffix is dropped).
+- `Mft::try_iter_with_options` no longer seeds the enumeration's start file
+  reference number from `low_usn`; enumeration always begins at record 0 and
+  `low_usn`/`high_usn` filter purely by USN, as the Win32 API intends.
+- `JournalIterOptionsBuilder::timeout` now takes a `std::time::Duration`
+  (truncated to whole seconds, matching the Win32 read API) instead of a raw
+  `u64`. The default is `Duration::ZERO` (block indefinitely while waiting).
 
 ### Removed
 
 - `pub type Usn = i64` alias (replaced by the `Usn(i64)` newtype).
 - `UsnEntry::pretty_format` and `MftEntry::pretty_format` — use the `Display`
-  impl; a multi-line formatter is available in `examples/pretty_print.rs`.
+  impl; a multi-line formatter is available in `examples/journal_pretty_print.rs`.
+- `UsnEntry::get_reason_string()` — use the `UsnReason` `Display` impl directly,
+  e.g. `entry.reason.to_string()` or `format!("{}", entry.reason)`.
 - `UsnError::OtherError(String)` catch-all variant.
-- `PathResolver::new_with_cache` (deprecated; use
-  `PathResolver::new(v).with_lru_cache(n)`).
+- `PathResolver::new_with_cache` — use
+  `PathResolver::new(v).with_directory_cache(n)`.
 - `Fid::from_u64`; use `Fid::new` or `Fid::from(u64)` instead.
 - External date/time crate integration from the public API.
 - Crate-root re-exports of `DEFAULT_JOURNAL_MAX_SIZE`,
@@ -110,6 +164,11 @@ and idiomatic Rust refactoring. **Breaking changes throughout** — see the
 ### Internal
 
 - `src/record.rs` renamed to `src/usn_record.rs`.
+- Unified the `FileAttributes` / `UsnReason` / `UsnSourceInfo` `Display` logic
+  into a single `crate::display::write_flag_names` helper.
+- Named `attr_header_flags` constants replace magic-number attribute-flag checks
+  in raw-`$MFT` entry construction; a shared `parse_record_at` helper removes the
+  duplicated look-up/borrow/validate/fix-up sequence in the raw-`$MFT` readers.
 
 ---
 
@@ -148,12 +207,12 @@ Or via mount point:
 ```diff
 - use usn_journal_rs::journal::EnumOptions;
 - let opts = EnumOptions { start_usn: 0, ..Default::default() };
-+ use usn_journal_rs::journal::{JournalIterOptions, USN_REASON_MASK_ALL};
++ use usn_journal_rs::journal::JournalIterOptions;
 + use std::num::NonZeroUsize;
 + use usn_journal_rs::{Usn, UsnReason};
 + let opts = JournalIterOptions::builder()
 +     .start_usn(Usn::new(0))
-+     .reason_mask(UsnReason::from_bits_retain(USN_REASON_MASK_ALL))
++     .reason_mask(UsnReason::ALL)
 +     .buffer_bytes(NonZeroUsize::new(64 * 1024).unwrap())
 +     .build();
 ```
@@ -191,19 +250,18 @@ Or via mount point:
 
 ```diff
 - let resolver = PathResolver::new_with_cache(&volume, 8192);
-+ use std::num::NonZeroUsize;
-+ let resolver = PathResolver::new(&volume)
-+     .with_lru_cache(NonZeroUsize::new(8192).unwrap());
++ // Plain integer capacity; pass 0 to disable the cache.
++ let resolver = PathResolver::new(&volume).with_directory_cache(8192);
 ```
 
-For maximum performance on full-volume scans, use the in-memory tree:
+For maximum performance on full-volume scans, use the raw-`$MFT` snapshot
+resolver, which walks an in-memory directory tree with no per-lookup syscalls:
 
 ```rust
 use usn_journal_rs::raw_mft::RawMft;
 
 let raw_mft = RawMft::new(&volume)?;
-let resolver = PathResolver::new(&volume)
-    .with_in_memory_tree(&raw_mft)?;
+let resolver = raw_mft.path_resolver()?;
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Iterate the USN change journal on drive `C:`:
 
 ```rust
 use usn_journal_rs::errors::UsnError;
-use usn_journal_rs::journal::{JournalIterOptions, UsnEntry, UsnJournal, USN_REASON_MASK_ALL};
+use usn_journal_rs::journal::{JournalIterOptions, UsnEntry, UsnJournal};
 use usn_journal_rs::volume::Volume;
 use usn_journal_rs::{Usn, UsnReason};
 use std::num::NonZeroUsize;
@@ -54,8 +54,8 @@ fn main() -> Result<(), UsnError> {
     let journal = UsnJournal::new(&volume);
 
     let opts = JournalIterOptions::builder()
-        .start_usn(Usn::new(0))
-        .reason_mask(UsnReason::from_bits_retain(USN_REASON_MASK_ALL))
+        .start_usn(Usn::ZERO)
+        .reason_mask(UsnReason::ALL)
         .only_on_close(false)
         .buffer_bytes(NonZeroUsize::new(64 * 1024).unwrap())
         .build();
@@ -63,6 +63,50 @@ fn main() -> Result<(), UsnError> {
     for result in journal.try_iter_with_options(opts)? {
         let entry: UsnEntry = result?;
         println!("{}", entry); // compact one-line Display
+    }
+    Ok(())
+}
+```
+
+### Watch for live changes
+
+`Volume` exposes convenience accessors — `journal()`, `mft()`, `raw_mft()`, and
+`path_resolver()` — so you rarely need to import the reader types directly. To
+follow the journal tail and resolve each change to a full path:
+
+```rust
+use usn_journal_rs::errors::UsnError;
+use usn_journal_rs::journal::JournalIterOptions;
+use usn_journal_rs::volume::Volume;
+
+fn main() -> Result<(), UsnError> {
+    let volume = Volume::from_drive_letter('C')?;
+    let journal = volume.journal();
+    let resolver = volume.path_resolver(); // resolve_path takes &self
+
+    // Start at the current tail, then block waiting for new records.
+    let tail = journal.query_or_create()?.next_usn;
+    let opts = JournalIterOptions::builder()
+        .start_usn(tail)
+        .wait_for_more(true)
+        .build();
+
+    for result in journal.try_iter_with_options(opts)? {
+        let entry = result?;
+        // Named predicates make change classification read naturally:
+        let kind = if entry.reason.is_file_create() {
+            "created"
+        } else if entry.reason.is_file_delete() {
+            "deleted"
+        } else if entry.reason.is_rename() {
+            "renamed"
+        } else {
+            "modified"
+        };
+        match resolver.resolve_path(&entry) {
+            Some(path) => println!("{kind}: {}", path.display()),
+            None => println!("{kind}: {}", entry.file_name.to_string_lossy()),
+        }
     }
     Ok(())
 }
@@ -84,7 +128,7 @@ All examples require Administrator privileges.
 
 ## Performance notes
 
-Benchmarks are run with [Divan](https://github.com/nvzqz/divan) on a 200 k-record NTFS volume.
+Benchmarks use [Criterion](https://github.com/bheisler/criterion.rs) on a 200 k-record NTFS volume.
 
 - **Raw `$MFT` iteration** — ~6× faster than 0.4.x (262 ms vs 1.64 s). Achieved via
   zero-copy fixup parsing (`VolumeReader::borrow_at`) and elimination of per-record memcpy.

--- a/benches/path_resolver.rs
+++ b/benches/path_resolver.rs
@@ -117,7 +117,7 @@ fn resolver_syscall_no_cache(c: &mut Criterion) {
 
     c.bench_function("resolver_syscall_no_cache", |b| {
         b.iter(|| {
-            let mut resolver = PathResolver::new(&volume).with_directory_cache(0);
+            let resolver = PathResolver::new(&volume).with_directory_cache(0);
             let mut count = 0u64;
 
             for entry in &entries {
@@ -142,7 +142,7 @@ fn resolver_syscall_directory_cache(c: &mut Criterion) {
 
     c.bench_function("resolver_syscall_directory_cache", |b| {
         b.iter(|| {
-            let mut resolver = PathResolver::new(&volume).with_directory_cache(8192);
+            let resolver = PathResolver::new(&volume).with_directory_cache(8192);
 
             // Warm-up pass to populate cache
             for entry in &entries {

--- a/examples/change_monitor.rs
+++ b/examples/change_monitor.rs
@@ -1,11 +1,6 @@
 //! Follow the live USN journal from its current tail and print new records as they arrive.
 
-use usn_journal_rs::{
-    errors::UsnError,
-    journal::{JournalIterOptions, UsnJournal},
-    path::PathResolver,
-    volume::Volume,
-};
+use usn_journal_rs::{errors::UsnError, journal::JournalIterOptions, volume::Volume};
 
 /// Run the example and print any top-level error.
 fn main() {
@@ -18,9 +13,9 @@ fn main() {
 fn run() -> Result<(), UsnError> {
     let drive_letter = 'D';
     let volume = Volume::from_drive_letter(drive_letter)?;
-    let usn_journal = UsnJournal::new(&volume);
+    let journal = volume.journal();
 
-    let journal_data = usn_journal.query(true)?;
+    let journal_data = journal.query_or_create()?;
 
     let enum_options = JournalIterOptions::builder()
         .start_usn(journal_data.next_usn)
@@ -28,9 +23,9 @@ fn run() -> Result<(), UsnError> {
         .wait_for_more(true)
         .build();
 
-    let mut path_resolver = PathResolver::new(&volume);
+    let path_resolver = volume.path_resolver();
 
-    for result in usn_journal.try_iter_with_options(enum_options)? {
+    for result in journal.try_iter_with_options(enum_options)? {
         match result {
             Ok(entry) => {
                 let full_path = path_resolver.resolve_path(&entry);

--- a/examples/enum_mft.rs
+++ b/examples/enum_mft.rs
@@ -1,6 +1,6 @@
 //! Enumerate `FSCTL_ENUM_USN_DATA` records and print each entry with its resolved path.
 
-use usn_journal_rs::{errors::UsnError, mft::Mft, path::PathResolver, volume::Volume};
+use usn_journal_rs::{errors::UsnError, volume::Volume};
 
 /// Run the example and print any top-level error.
 fn main() {
@@ -13,8 +13,8 @@ fn main() {
 fn run() -> Result<(), UsnError> {
     let drive_letter = 'C';
     let volume = Volume::from_drive_letter(drive_letter)?;
-    let mft = Mft::new(&volume);
-    let mut path_resolver = PathResolver::new(&volume);
+    let mft = volume.mft();
+    let path_resolver = volume.path_resolver();
 
     for result in mft.try_iter()? {
         match result {

--- a/examples/journal_pretty_print.rs
+++ b/examples/journal_pretty_print.rs
@@ -31,11 +31,7 @@ fn pretty_format<P: AsRef<Path>>(entry: &UsnEntry, full_path_opt: Option<P>) -> 
         None => format!("{:?}", entry.time),
     };
     output.push_str(&format!("{:<20}: {}\n", "Timestamp", timestamp_str));
-    output.push_str(&format!(
-        "{:<20}: {}\n",
-        "Reason",
-        entry.get_reason_string()
-    ));
+    output.push_str(&format!("{:<20}: {}\n", "Reason", entry.reason));
 
     if let Some(full_path) = full_path_opt {
         output.push_str(&format!(
@@ -80,7 +76,7 @@ fn format_local_filetime(filetime: Filetime) -> Option<String> {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let volume = Volume::from_drive_letter('C')?;
     let usn_journal = UsnJournal::new(&volume);
-    let mut path_resolver = PathResolver::new(&volume);
+    let path_resolver = PathResolver::new(&volume);
 
     for result in usn_journal.try_iter()?.take(10) {
         match result {

--- a/examples/read_journal.rs
+++ b/examples/read_journal.rs
@@ -1,6 +1,6 @@
 //! Iterate the USN journal and print each entry with its resolved path when available.
 
-use usn_journal_rs::{errors::UsnError, journal::UsnJournal, path::PathResolver, volume::Volume};
+use usn_journal_rs::{errors::UsnError, volume::Volume};
 
 /// Run the example and print any top-level error.
 fn main() {
@@ -13,11 +13,11 @@ fn main() {
 fn run() -> Result<(), UsnError> {
     let drive_letter = 'D';
     let volume = Volume::from_drive_letter(drive_letter)?;
-    let usn_journal = UsnJournal::new(&volume);
+    let journal = volume.journal();
 
-    let mut path_resolver = PathResolver::new(&volume);
+    let path_resolver = volume.path_resolver();
 
-    for result in usn_journal.try_iter()? {
+    for result in journal.try_iter()? {
         match result {
             Ok(entry) => {
                 let full_path = path_resolver.resolve_path(&entry);

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,0 +1,41 @@
+//! Shared formatting helpers for the crate's bitflag newtypes.
+//!
+//! The USN reason, file-attribute, and source-info bitmasks all render the
+//! same way: a list of set flag names joined by a separator, falling back to
+//! `NONE` when no bits are set and to a hexadecimal value when only unknown
+//! bits remain. Centralizing the logic here keeps the three `Display`
+//! implementations consistent.
+
+use std::fmt;
+
+/// Write the names of the set flags in `bits`, or a `NONE`/hex fallback.
+///
+/// For every `(mask, name)` pair whose bits are fully present in `bits`, the
+/// name is written, separated by `separator`. If no known flag matches, the
+/// output is `NONE` when `bits == 0` and `0x{bits:x}` otherwise (so unknown
+/// bits are still visible).
+pub(crate) fn write_flag_names(
+    f: &mut fmt::Formatter<'_>,
+    bits: u32,
+    names: &[(u32, &str)],
+    separator: &str,
+) -> fmt::Result {
+    let mut wrote = false;
+    for (mask, name) in names {
+        if *mask != 0 && bits & *mask == *mask {
+            if wrote {
+                f.write_str(separator)?;
+            }
+            f.write_str(name)?;
+            wrote = true;
+        }
+    }
+
+    if wrote {
+        Ok(())
+    } else if bits == 0 {
+        f.write_str("NONE")
+    } else {
+        write!(f, "0x{bits:x}")
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,14 @@ pub enum UsnError {
     #[error("This operation requires Administrator privileges")]
     NotElevated,
 
+    /// The volume's USN change journal is not active.
+    ///
+    /// Returned by [`crate::journal::UsnJournal::query`] when the volume has no
+    /// active change journal. Call [`crate::journal::UsnJournal::query_or_create`]
+    /// to create one on demand.
+    #[error("The USN change journal is not active on this volume")]
+    JournalNotActive,
+
     /// Caller-provided options failed validation.
     #[error("Invalid options: {0}")]
     InvalidOptions(&'static str),
@@ -69,7 +77,7 @@ pub enum UsnError {
 
     /// A mount point path could not be resolved to a volume.
     #[error("Invalid mount point: {0}")]
-    InvalidMountPointError(String),
+    InvalidMountPoint(String),
 
     /// A timestamp could not be represented in the target format.
     #[error("Invalid timestamp: {0}")]
@@ -232,6 +240,18 @@ mod tests {
         }
 
         #[test]
+        fn test_journal_not_active_display_and_classification() {
+            let error = UsnError::JournalNotActive;
+            assert_eq!(
+                error.to_string(),
+                "The USN change journal is not active on this volume"
+            );
+            // It is a precondition error, neither I/O nor on-disk parse.
+            assert!(!error.is_io_error());
+            assert!(!error.is_parse_error());
+        }
+
+        #[test]
         fn test_buffer_too_small_display() {
             let error = UsnError::BufferTooSmall {
                 needed: 1024,
@@ -307,7 +327,7 @@ mod tests {
         #[test]
         fn test_invalid_mount_point_error_display() {
             let mount_point = "C:\\invalid\\path";
-            let error = UsnError::InvalidMountPointError(mount_point.to_string());
+            let error = UsnError::InvalidMountPoint(mount_point.to_string());
             let error_string = error.to_string();
             assert_eq!(error_string, "Invalid mount point: C:\\invalid\\path");
         }
@@ -405,7 +425,7 @@ mod tests {
             ];
 
             for path in invalid_paths {
-                let error = UsnError::InvalidMountPointError(path.to_string());
+                let error = UsnError::InvalidMountPoint(path.to_string());
                 assert!(error.to_string().contains("Invalid mount point:"));
                 assert!(error.to_string().contains(path));
             }

--- a/src/file_attributes.rs
+++ b/src/file_attributes.rs
@@ -10,65 +10,50 @@ pub(crate) trait FileAttributeView {
     /// Returns true if the bitmask marks a directory.
     #[inline]
     fn has_directory_attribute(&self) -> bool {
-        self.file_attributes()
-            .contains(crate::FileAttributes::DIRECTORY)
+        self.file_attributes().is_directory()
     }
 
     /// Returns true if the bitmask marks a hidden item.
     #[inline]
     fn has_hidden_attribute(&self) -> bool {
-        self.file_attributes()
-            .contains(crate::FileAttributes::HIDDEN)
+        self.file_attributes().is_hidden()
     }
 }
 
 /// Display names for known `FILE_ATTRIBUTE_*` bits.
-const FILE_ATTRIBUTE_NAMES: &[(crate::FileAttributes, &str)] = &[
-    (crate::FileAttributes::READ_ONLY, "READ_ONLY"),
-    (crate::FileAttributes::HIDDEN, "HIDDEN"),
-    (crate::FileAttributes::SYSTEM, "SYSTEM"),
-    (crate::FileAttributes::DIRECTORY, "DIRECTORY"),
-    (crate::FileAttributes::ARCHIVE, "ARCHIVE"),
-    (crate::FileAttributes::DEVICE, "DEVICE"),
-    (crate::FileAttributes::NORMAL, "NORMAL"),
-    (crate::FileAttributes::TEMPORARY, "TEMPORARY"),
-    (crate::FileAttributes::SPARSE_FILE, "SPARSE_FILE"),
-    (crate::FileAttributes::REPARSE_POINT, "REPARSE_POINT"),
-    (crate::FileAttributes::COMPRESSED, "COMPRESSED"),
-    (crate::FileAttributes::OFFLINE, "OFFLINE"),
+const FILE_ATTRIBUTE_NAMES: &[(u32, &str)] = &[
+    (crate::FileAttributes::READ_ONLY.bits(), "READ_ONLY"),
+    (crate::FileAttributes::HIDDEN.bits(), "HIDDEN"),
+    (crate::FileAttributes::SYSTEM.bits(), "SYSTEM"),
+    (crate::FileAttributes::DIRECTORY.bits(), "DIRECTORY"),
+    (crate::FileAttributes::ARCHIVE.bits(), "ARCHIVE"),
+    (crate::FileAttributes::DEVICE.bits(), "DEVICE"),
+    (crate::FileAttributes::NORMAL.bits(), "NORMAL"),
+    (crate::FileAttributes::TEMPORARY.bits(), "TEMPORARY"),
+    (crate::FileAttributes::SPARSE_FILE.bits(), "SPARSE_FILE"),
+    (crate::FileAttributes::REPARSE_POINT.bits(), "REPARSE_POINT"),
+    (crate::FileAttributes::COMPRESSED.bits(), "COMPRESSED"),
+    (crate::FileAttributes::OFFLINE.bits(), "OFFLINE"),
     (
-        crate::FileAttributes::NOT_CONTENT_INDEXED,
+        crate::FileAttributes::NOT_CONTENT_INDEXED.bits(),
         "NOT_CONTENT_INDEXED",
     ),
-    (crate::FileAttributes::ENCRYPTED, "ENCRYPTED"),
-    (crate::FileAttributes::INTEGRITY_STREAM, "INTEGRITY_STREAM"),
-    (crate::FileAttributes::VIRTUAL, "VIRTUAL"),
-    (crate::FileAttributes::NO_SCRUB_DATA, "NO_SCRUB_DATA"),
-    (crate::FileAttributes::RECALL_ON_OPEN, "RECALL_ON_OPEN"),
+    (crate::FileAttributes::ENCRYPTED.bits(), "ENCRYPTED"),
     (
-        crate::FileAttributes::RECALL_ON_DATA_ACCESS,
+        crate::FileAttributes::INTEGRITY_STREAM.bits(),
+        "INTEGRITY_STREAM",
+    ),
+    (crate::FileAttributes::VIRTUAL.bits(), "VIRTUAL"),
+    (crate::FileAttributes::NO_SCRUB_DATA.bits(), "NO_SCRUB_DATA"),
+    (crate::FileAttributes::RECALL_ON_OPEN.bits(), "RECALL_ON_OPEN"),
+    (
+        crate::FileAttributes::RECALL_ON_DATA_ACCESS.bits(),
         "RECALL_ON_DATA_ACCESS",
     ),
 ];
 
 impl fmt::Display for crate::FileAttributes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut wrote = false;
-        for (flag, name) in FILE_ATTRIBUTE_NAMES {
-            if self.contains(*flag) {
-                if wrote {
-                    f.write_str(" | ")?;
-                }
-                f.write_str(name)?;
-                wrote = true;
-            }
-        }
-        if wrote {
-            Ok(())
-        } else if self.is_empty() {
-            f.write_str("NONE")
-        } else {
-            write!(f, "0x{:x}", self.bits())
-        }
+        crate::display::write_flag_names(f, self.bits(), FILE_ATTRIBUTE_NAMES, " | ")
     }
 }

--- a/src/journal/data.rs
+++ b/src/journal/data.rs
@@ -1,6 +1,7 @@
 //! USN journal state structure.
 
 use crate::Usn;
+use std::fmt;
 use windows::Win32::System::Ioctl::USN_JOURNAL_DATA_V0;
 
 /// Represents the USN journal state on an NTFS/ReFS volume.
@@ -34,5 +35,65 @@ impl From<USN_JOURNAL_DATA_V0> for UsnJournalData {
             maximum_size: data.MaximumSize,
             allocation_delta: data.AllocationDelta,
         }
+    }
+}
+
+impl fmt::Display for UsnJournalData {
+    /// Compact one-line summary suitable for logging.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "journal 0x{:x}: usn {}..{} (lowest_valid {}), max_size {} bytes, delta {} bytes",
+            self.journal_id,
+            self.first_usn,
+            self.next_usn,
+            self.lowest_valid_usn,
+            self.maximum_size,
+            self.allocation_delta,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> UsnJournalData {
+        UsnJournalData {
+            journal_id: 0xABCD,
+            first_usn: Usn::new(0x1000),
+            next_usn: Usn::new(0x5000),
+            lowest_valid_usn: Usn::new(0x800),
+            max_usn: Usn::new(0x10_000),
+            maximum_size: 32 * 1024 * 1024,
+            allocation_delta: 8 * 1024 * 1024,
+        }
+    }
+
+    #[test]
+    fn from_win32_maps_all_fields() {
+        let raw = USN_JOURNAL_DATA_V0 {
+            UsnJournalID: 0xABCD,
+            FirstUsn: 0x1000,
+            NextUsn: 0x5000,
+            LowestValidUsn: 0x800,
+            MaxUsn: 0x10_000,
+            MaximumSize: 32 * 1024 * 1024,
+            AllocationDelta: 8 * 1024 * 1024,
+        };
+        let data = UsnJournalData::from(raw);
+        assert_eq!(data.journal_id, 0xABCD);
+        assert_eq!(data.first_usn, Usn::new(0x1000));
+        assert_eq!(data.next_usn, Usn::new(0x5000));
+        assert_eq!(data.lowest_valid_usn, Usn::new(0x800));
+        assert_eq!(data.max_usn, Usn::new(0x10_000));
+    }
+
+    #[test]
+    fn display_is_compact_summary() {
+        let text = sample().to_string();
+        assert!(text.contains("journal 0xabcd"));
+        assert!(text.contains("usn 4096..20480"));
+        assert!(text.contains("lowest_valid 2048"));
     }
 }

--- a/src/journal/defaults.rs
+++ b/src/journal/defaults.rs
@@ -19,4 +19,7 @@ pub const DEFAULT_JOURNAL_MAX_SIZE: u64 = 32 * 1024 * 1024; // 32MB
 pub const DEFAULT_JOURNAL_ALLOCATION_DELTA: u64 = 8 * 1024 * 1024; // 8MB
 
 /// Reason mask that matches every USN reason flag.
-pub const USN_REASON_MASK_ALL: u32 = 0xFFFFFFFF;
+///
+/// Kept as a raw `u32` for direct use in the low-level Win32 read structures;
+/// prefer the strongly-typed [`crate::UsnReason::ALL`] in public option builders.
+pub const USN_REASON_MASK_ALL: u32 = crate::UsnReason::ALL.bits();

--- a/src/journal/entry.rs
+++ b/src/journal/entry.rs
@@ -7,7 +7,7 @@ use crate::file_attributes::FileAttributeView;
 use crate::usn_record::UsnRecordView;
 use crate::{Fid, FileAttributes, Filetime, Usn, UsnReason, UsnSourceInfo};
 
-use super::reason::{CompactReason, format_reason};
+use super::reason::CompactReason;
 
 /// Owned representation of a USN journal entry.
 ///
@@ -74,10 +74,53 @@ impl UsnEntry {
         <Self as FileAttributeView>::has_hidden_attribute(self)
     }
 
-    /// Converts a USN reason bitfield to a human-readable string using Windows constants.
+    /// Returns true if this entry is marked read-only.
     #[must_use]
-    pub fn get_reason_string(&self) -> String {
-        format_reason(self.reason)
+    #[inline]
+    pub fn is_read_only(&self) -> bool {
+        self.file_attributes.is_read_only()
+    }
+
+    /// Returns true if this entry has the system attribute set.
+    #[must_use]
+    #[inline]
+    pub fn is_system(&self) -> bool {
+        self.file_attributes.is_system()
+    }
+
+    /// Returns true if this entry has the archive attribute set.
+    #[must_use]
+    #[inline]
+    pub fn is_archive(&self) -> bool {
+        self.file_attributes.is_archive()
+    }
+
+    /// Returns true if this entry is a reparse point (symlink, junction, mount point, ...).
+    #[must_use]
+    #[inline]
+    pub fn is_reparse_point(&self) -> bool {
+        self.file_attributes.is_reparse_point()
+    }
+
+    /// Returns true if this entry is stored compressed on disk.
+    #[must_use]
+    #[inline]
+    pub fn is_compressed(&self) -> bool {
+        self.file_attributes.is_compressed()
+    }
+
+    /// Returns true if this entry is stored encrypted on disk.
+    #[must_use]
+    #[inline]
+    pub fn is_encrypted(&self) -> bool {
+        self.file_attributes.is_encrypted()
+    }
+
+    /// Returns true if this entry contains sparse data.
+    #[must_use]
+    #[inline]
+    pub fn is_sparse(&self) -> bool {
+        self.file_attributes.is_sparse()
     }
 }
 

--- a/src/journal/iter.rs
+++ b/src/journal/iter.rs
@@ -21,7 +21,7 @@ pub(super) struct UsnJournalIterConfig {
     pub(super) reason_mask: u32,
     /// Whether records should only be returned once the handle closes.
     pub(super) return_only_on_close: u32,
-    /// Kernel wait timeout in 100-nanosecond units.
+    /// Kernel wait timeout in whole seconds (`0` blocks indefinitely).
     pub(super) timeout: u64,
     /// Number of bytes the kernel should wait for before returning.
     pub(super) bytes_to_wait_for: u64,
@@ -47,7 +47,7 @@ pub struct UsnJournalIter {
     reason_mask: u32,
     /// Whether only close events should be returned.
     return_only_on_close: u32,
-    /// Kernel wait timeout in 100-nanosecond units.
+    /// Kernel wait timeout in whole seconds (`0` blocks indefinitely).
     timeout: u64,
     /// Number of bytes to wait for before the kernel returns.
     bytes_to_wait_for: u64,

--- a/src/journal/journal.rs
+++ b/src/journal/journal.rs
@@ -12,6 +12,7 @@ use windows::Win32::System::Ioctl::{
 };
 
 use crate::UsnResult;
+use crate::errors::UsnError;
 use crate::volume::Volume;
 
 use super::data::UsnJournalData;
@@ -48,7 +49,7 @@ impl<'a> UsnJournal<'a> {
     /// front; subsequent per-record errors are surfaced as iterator items.
     #[must_use = "iterators are lazy and do nothing unless consumed"]
     pub fn try_iter(&self) -> UsnResult<UsnJournalIter> {
-        let journal_data = self.query(true)?;
+        let journal_data = self.query_or_create()?;
         Ok(UsnJournalIter::new(
             self.volume.handle,
             journal_data.journal_id,
@@ -69,7 +70,7 @@ impl<'a> UsnJournal<'a> {
     /// to handle individual entry errors gracefully without stopping iteration.
     #[must_use = "iterators are lazy and do nothing unless consumed"]
     pub fn try_iter_with_options(&self, options: JournalIterOptions) -> UsnResult<UsnJournalIter> {
-        let journal_data = self.query(true)?;
+        let journal_data = self.query_or_create()?;
         Ok(UsnJournalIter::new(
             self.volume.handle,
             journal_data.journal_id,
@@ -78,40 +79,49 @@ impl<'a> UsnJournal<'a> {
                 next_start_usn: options.start_usn.get(),
                 reason_mask: options.reason_mask.bits(),
                 return_only_on_close: options.only_on_close as u32,
-                timeout: options.timeout,
+                timeout: options.timeout_secs,
                 bytes_to_wait_for: options.wait_for_more as u64,
             },
         ))
     }
 
-    /// Query the USN journal state for a volume, optionally creating it if not active.
+    /// Query the current USN journal state for the volume.
     ///
-    /// # Arguments
-    /// * `create_if_not_active` - If true, create the journal if it does not exist.
+    /// # Errors
     ///
-    /// # Returns
-    /// * `Ok(UsnJournalData)` - The current journal state.
-    /// * `Err(UsnError)` - If the query or creation fails.
-    pub fn query(&self, create_if_not_active: bool) -> UsnResult<UsnJournalData> {
+    /// Returns [`UsnError::JournalNotActive`] if the volume has no active change
+    /// journal. Use [`Self::query_or_create`] to create one on demand instead.
+    pub fn query(&self) -> UsnResult<UsnJournalData> {
         match self.query_core() {
-            Err(err) => {
-                if err.code() == ERROR_JOURNAL_NOT_ACTIVE.into() && create_if_not_active {
-                    self.create_or_update(
-                        DEFAULT_JOURNAL_MAX_SIZE,
-                        DEFAULT_JOURNAL_ALLOCATION_DELTA,
-                    )?;
-
-                    let journal_data = self.query_core()?;
-                    Ok(journal_data.into())
-                } else {
-                    warn!("Error querying USN journal: {err}");
-                    Err(err.into())
-                }
-            }
             Ok(journal_data) => {
                 debug!("USN journal data: {journal_data:#?}");
                 Ok(journal_data.into())
             }
+            Err(err) if err.code() == ERROR_JOURNAL_NOT_ACTIVE.into() => {
+                Err(UsnError::JournalNotActive)
+            }
+            Err(err) => {
+                warn!("Error querying USN journal: {err}");
+                Err(err.into())
+            }
+        }
+    }
+
+    /// Query the USN journal state, creating the journal first if it is not active.
+    ///
+    /// Equivalent to [`Self::query`] but transparently creates a default journal
+    /// (see [`Self::create_or_update`]) when the volume has none, then re-queries.
+    pub fn query_or_create(&self) -> UsnResult<UsnJournalData> {
+        match self.query() {
+            Err(UsnError::JournalNotActive) => {
+                self.create_or_update(
+                    DEFAULT_JOURNAL_MAX_SIZE,
+                    DEFAULT_JOURNAL_ALLOCATION_DELTA,
+                )?;
+                let journal_data = self.query_core()?;
+                Ok(journal_data.into())
+            }
+            other => other,
         }
     }
 
@@ -190,7 +200,7 @@ impl<'a> UsnJournal<'a> {
     /// # Returns
     /// * `Ok(())` on success, or `Err(UsnError)` on failure.
     pub fn delete(&self) -> UsnResult<()> {
-        let journal_data = self.query(false)?;
+        let journal_data = self.query()?;
         let delete_flags: USN_DELETE_FLAGS = USN_DELETE_FLAG_DELETE | USN_DELETE_FLAG_NOTIFY;
         let delete_data = DELETE_USN_JOURNAL_DATA {
             UsnJournalID: journal_data.journal_id,
@@ -216,5 +226,16 @@ impl<'a> UsnJournal<'a> {
         debug!("Deleted USN journal successfully.");
 
         Ok(())
+    }
+}
+
+impl Volume {
+    /// Create a [`UsnJournal`] reader for this volume.
+    ///
+    /// Convenience for [`UsnJournal::new`], so you can write
+    /// `volume.journal().try_iter()?` without importing [`UsnJournal`].
+    #[must_use]
+    pub fn journal(&self) -> UsnJournal<'_> {
+        UsnJournal::new(self)
     }
 }

--- a/src/journal/options.rs
+++ b/src/journal/options.rs
@@ -2,8 +2,9 @@
 
 use crate::{Usn, UsnReason};
 use std::num::NonZeroUsize;
+use std::time::Duration;
 
-use super::defaults::{DEFAULT_BUFFER_BYTES_NONZERO, USN_REASON_MASK_ALL};
+use super::defaults::DEFAULT_BUFFER_BYTES_NONZERO;
 
 #[derive(Debug, Clone)]
 /// Options for enumerating the USN journal.
@@ -18,8 +19,9 @@ pub struct JournalIterOptions {
     pub(crate) reason_mask: UsnReason,
     /// Whether only close events should be returned.
     pub(crate) only_on_close: bool,
-    /// Kernel timeout for blocking reads.
-    pub(crate) timeout: u64,
+    /// Kernel timeout, in whole seconds, for blocking reads (`wait_for_more`).
+    /// `0` means block indefinitely until data is available.
+    pub(crate) timeout_secs: u64,
     /// Whether the iterator should wait for more records.
     pub(crate) wait_for_more: bool,
     /// Size of the kernel output buffer.
@@ -30,9 +32,9 @@ impl Default for JournalIterOptions {
     fn default() -> Self {
         JournalIterOptions {
             start_usn: Usn::new(0),
-            reason_mask: UsnReason::from_bits_retain(USN_REASON_MASK_ALL),
+            reason_mask: UsnReason::ALL,
             only_on_close: false,
-            timeout: 0,
+            timeout_secs: 0,
             wait_for_more: false,
             buffer_bytes: DEFAULT_BUFFER_BYTES_NONZERO,
         }
@@ -73,9 +75,14 @@ impl JournalIterOptionsBuilder {
         self
     }
 
-    /// Set the timeout (Win32 USN read timeout, see `READ_USN_JOURNAL_DATA_V0`).
-    pub fn timeout(mut self, v: u64) -> Self {
-        self.inner.timeout = v;
+    /// Set the blocking-read timeout.
+    ///
+    /// Only meaningful together with [`Self::wait_for_more`]. The Win32 USN read
+    /// API (`READ_USN_JOURNAL_DATA`) expresses this timeout in whole seconds, so
+    /// the supplied [`Duration`] is truncated to `as_secs()`. The default —
+    /// [`Duration::ZERO`] — blocks indefinitely until records are available.
+    pub fn timeout(mut self, v: Duration) -> Self {
+        self.inner.timeout_secs = v.as_secs();
         self
     }
 
@@ -95,5 +102,47 @@ impl JournalIterOptionsBuilder {
     #[must_use]
     pub fn build(self) -> JournalIterOptions {
         self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_uses_full_reason_mask() {
+        assert_eq!(JournalIterOptions::default().reason_mask, UsnReason::ALL);
+    }
+
+    #[test]
+    fn default_timeout_is_zero() {
+        assert_eq!(JournalIterOptions::default().timeout_secs, 0);
+    }
+
+    #[test]
+    fn timeout_truncates_duration_to_whole_seconds() {
+        let opts = JournalIterOptions::builder()
+            .timeout(Duration::from_millis(2_500))
+            .build();
+        assert_eq!(opts.timeout_secs, 2);
+    }
+
+    #[test]
+    fn builder_round_trips_values() {
+        let opts = JournalIterOptions::builder()
+            .start_usn(Usn::new(42))
+            .reason_mask(UsnReason::FILE_CREATE)
+            .only_on_close(true)
+            .wait_for_more(true)
+            .timeout(Duration::from_secs(7))
+            .buffer_bytes(NonZeroUsize::new(8 * 1024).unwrap())
+            .build();
+
+        assert_eq!(opts.start_usn, Usn::new(42));
+        assert_eq!(opts.reason_mask, UsnReason::FILE_CREATE);
+        assert!(opts.only_on_close);
+        assert!(opts.wait_for_more);
+        assert_eq!(opts.timeout_secs, 7);
+        assert_eq!(opts.buffer_bytes.get(), 8 * 1024);
     }
 }

--- a/src/journal/reason.rs
+++ b/src/journal/reason.rs
@@ -3,73 +3,81 @@
 use std::fmt;
 
 use crate::UsnReason;
+use crate::display::write_flag_names;
 
 /// Display names for known `USN_REASON_*` bits.
-const REASON_FLAGS: &[(UsnReason, &str)] = &[
-    (UsnReason::DATA_OVERWRITE, "DATA_OVERWRITE"),
-    (UsnReason::DATA_EXTEND, "DATA_EXTEND"),
-    (UsnReason::DATA_TRUNCATION, "DATA_TRUNCATION"),
-    (UsnReason::NAMED_DATA_OVERWRITE, "NAMED_DATA_OVERWRITE"),
-    (UsnReason::NAMED_DATA_EXTEND, "NAMED_DATA_EXTEND"),
-    (UsnReason::NAMED_DATA_TRUNCATION, "NAMED_DATA_TRUNCATION"),
-    (UsnReason::FILE_CREATE, "FILE_CREATE"),
-    (UsnReason::FILE_DELETE, "FILE_DELETE"),
-    (UsnReason::EA_CHANGE, "EA_CHANGE"),
-    (UsnReason::SECURITY_CHANGE, "SECURITY_CHANGE"),
-    (UsnReason::RENAME_OLD_NAME, "RENAME_OLD_NAME"),
-    (UsnReason::RENAME_NEW_NAME, "RENAME_NEW_NAME"),
-    (UsnReason::INDEXABLE_CHANGE, "INDEXABLE_CHANGE"),
-    (UsnReason::BASIC_INFO_CHANGE, "BASIC_INFO_CHANGE"),
-    (UsnReason::HARD_LINK_CHANGE, "HARD_LINK_CHANGE"),
-    (UsnReason::COMPRESSION_CHANGE, "COMPRESSION_CHANGE"),
-    (UsnReason::ENCRYPTION_CHANGE, "ENCRYPTION_CHANGE"),
-    (UsnReason::OBJECT_ID_CHANGE, "OBJECT_ID_CHANGE"),
-    (UsnReason::REPARSE_POINT_CHANGE, "REPARSE_POINT_CHANGE"),
-    (UsnReason::STREAM_CHANGE, "STREAM_CHANGE"),
-    (UsnReason::TRANSACTED_CHANGE, "TRANSACTED_CHANGE"),
-    (UsnReason::INTEGRITY_CHANGE, "INTEGRITY_CHANGE"),
+const REASON_FLAG_NAMES: &[(u32, &str)] = &[
+    (UsnReason::DATA_OVERWRITE.bits(), "DATA_OVERWRITE"),
+    (UsnReason::DATA_EXTEND.bits(), "DATA_EXTEND"),
+    (UsnReason::DATA_TRUNCATION.bits(), "DATA_TRUNCATION"),
+    (UsnReason::NAMED_DATA_OVERWRITE.bits(), "NAMED_DATA_OVERWRITE"),
+    (UsnReason::NAMED_DATA_EXTEND.bits(), "NAMED_DATA_EXTEND"),
     (
-        UsnReason::DESIRED_STORAGE_CLASS_CHANGE,
+        UsnReason::NAMED_DATA_TRUNCATION.bits(),
+        "NAMED_DATA_TRUNCATION",
+    ),
+    (UsnReason::FILE_CREATE.bits(), "FILE_CREATE"),
+    (UsnReason::FILE_DELETE.bits(), "FILE_DELETE"),
+    (UsnReason::EA_CHANGE.bits(), "EA_CHANGE"),
+    (UsnReason::SECURITY_CHANGE.bits(), "SECURITY_CHANGE"),
+    (UsnReason::RENAME_OLD_NAME.bits(), "RENAME_OLD_NAME"),
+    (UsnReason::RENAME_NEW_NAME.bits(), "RENAME_NEW_NAME"),
+    (UsnReason::INDEXABLE_CHANGE.bits(), "INDEXABLE_CHANGE"),
+    (UsnReason::BASIC_INFO_CHANGE.bits(), "BASIC_INFO_CHANGE"),
+    (UsnReason::HARD_LINK_CHANGE.bits(), "HARD_LINK_CHANGE"),
+    (UsnReason::COMPRESSION_CHANGE.bits(), "COMPRESSION_CHANGE"),
+    (UsnReason::ENCRYPTION_CHANGE.bits(), "ENCRYPTION_CHANGE"),
+    (UsnReason::OBJECT_ID_CHANGE.bits(), "OBJECT_ID_CHANGE"),
+    (UsnReason::REPARSE_POINT_CHANGE.bits(), "REPARSE_POINT_CHANGE"),
+    (UsnReason::STREAM_CHANGE.bits(), "STREAM_CHANGE"),
+    (UsnReason::TRANSACTED_CHANGE.bits(), "TRANSACTED_CHANGE"),
+    (UsnReason::INTEGRITY_CHANGE.bits(), "INTEGRITY_CHANGE"),
+    (
+        UsnReason::DESIRED_STORAGE_CLASS_CHANGE.bits(),
         "DESIRED_STORAGE_CLASS_CHANGE",
     ),
-    (UsnReason::CLOSE, "CLOSE"),
+    (UsnReason::CLOSE.bits(), "CLOSE"),
 ];
-
-/// Convert a USN reason bitfield to a human-readable string.
-pub(super) fn format_reason(reason: UsnReason) -> String {
-    reason.to_string()
-}
 
 /// Compact formatter for `UsnReason` that omits spaces around separators.
 pub(super) struct CompactReason(pub(super) UsnReason);
 
 impl fmt::Display for CompactReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_reason(self.0, f, "|")
+        write_flag_names(f, self.0.bits(), REASON_FLAG_NAMES, "|")
     }
 }
 
 impl fmt::Display for UsnReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_reason(*self, f, " | ")
+        write_flag_names(f, self.bits(), REASON_FLAG_NAMES, " | ")
     }
 }
 
-/// Write a human-readable list of reason names separated by the provided delimiter.
-fn fmt_reason(reason: UsnReason, f: &mut fmt::Formatter<'_>, separator: &str) -> fmt::Result {
-    let mut wrote = false;
-    for (flag, name) in REASON_FLAGS {
-        if reason.contains(*flag) {
-            if wrote {
-                f.write_str(separator)?;
-            }
-            f.write_str(name)?;
-            wrote = true;
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_is_none_for_empty() {
+        assert_eq!(UsnReason::empty().to_string(), "NONE");
     }
-    if wrote {
-        Ok(())
-    } else {
-        f.write_str("UNKNOWN")
+
+    #[test]
+    fn display_lists_known_flags_with_separator() {
+        let reason = UsnReason::FILE_CREATE | UsnReason::CLOSE;
+        assert_eq!(reason.to_string(), "FILE_CREATE | CLOSE");
+    }
+
+    #[test]
+    fn compact_display_omits_spaces() {
+        let reason = UsnReason::FILE_CREATE | UsnReason::CLOSE;
+        assert_eq!(CompactReason(reason).to_string(), "FILE_CREATE|CLOSE");
+    }
+
+    #[test]
+    fn display_uses_hex_for_unknown_bits() {
+        let reason = UsnReason::from_bits_retain(0x0000_0008);
+        assert_eq!(reason.to_string(), "0x8");
     }
 }

--- a/src/journal/tests.rs
+++ b/src/journal/tests.rs
@@ -228,7 +228,7 @@ fn usn_entry_reason_string_conversion() {
     let record = unsafe { &*(record_data.as_ptr() as *const USN_RECORD_V2) };
 
     let entry = UsnEntry::new(crate::usn_record::UsnRecordView::V2(record));
-    let reason_string = entry.get_reason_string();
+    let reason_string = entry.reason.to_string();
 
     assert!(reason_string.contains("FILE_CREATE"));
     assert!(reason_string.contains("DATA_EXTEND"));
@@ -237,17 +237,16 @@ fn usn_entry_reason_string_conversion() {
 }
 
 #[test]
-fn usn_entry_unknown_reason() {
+fn usn_entry_empty_reason() {
     let record_data = create_mock_usn_record(
-        0x6000, 0x789123, 0x654321, 0, // No known reason flags
+        0x6000, 0x789123, 0x654321, 0, // No reason flags set
         "test.txt", 0,
     );
 
     let record = unsafe { &*(record_data.as_ptr() as *const USN_RECORD_V2) };
 
     let entry = UsnEntry::new(crate::usn_record::UsnRecordView::V2(record));
-    let reason_string = entry.get_reason_string();
-    assert_eq!(reason_string, "UNKNOWN");
+    assert_eq!(entry.reason.to_string(), "NONE");
 }
 
 #[test]
@@ -272,4 +271,29 @@ fn usn_entry_creation_v3_extended_ids() {
     assert_eq!(entry.file_name, OsString::from("refs.txt"));
     assert!(entry.fid.is_extended());
     assert!(entry.parent_fid.is_extended());
+}
+
+#[test]
+fn usn_entry_attribute_predicates_delegate_to_file_attributes() {
+    use crate::{FileAttributes, Filetime, UsnReason, UsnSourceInfo};
+
+    let entry = UsnEntry {
+        usn: Usn::new(1),
+        time: Filetime::new(0),
+        fid: Fid::new(0x10),
+        parent_fid: Fid::new(0x5),
+        reason: UsnReason::FILE_CREATE,
+        source_info: UsnSourceInfo::empty(),
+        file_name: OsString::from("archive.enc"),
+        file_attributes: FileAttributes::ENCRYPTED | FileAttributes::ARCHIVE,
+    };
+
+    assert!(entry.is_encrypted());
+    assert!(entry.is_archive());
+    assert!(!entry.is_compressed());
+    assert!(!entry.is_reparse_point());
+    assert!(!entry.is_system());
+    // Reason predicates on the same entry.
+    assert!(entry.reason.is_file_create());
+    assert!(!entry.reason.is_file_delete());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,14 +16,12 @@
 //!
 //! ## Example: Enumerate USN Journal
 //! ```no_run
-//! use usn_journal_rs::{volume::Volume, journal::UsnJournal};
+//! use usn_journal_rs::volume::Volume;
 //!
-//! let drive_letter = 'C';
-//! let volume = Volume::from_drive_letter(drive_letter).unwrap();
-//! let journal = UsnJournal::new(&volume);
-//! for result in journal.try_iter().unwrap().take(10) {
+//! let volume = Volume::from_drive_letter('C').unwrap();
+//! for result in volume.journal().try_iter().unwrap().take(10) {
 //!     match result {
-//!         Ok(entry) => println!("USN entry: {entry:?}"),
+//!         Ok(entry) => println!("USN entry: {entry}"),
 //!         Err(e) => eprintln!("Error reading entry: {e}"),
 //!     }
 //! }
@@ -31,14 +29,12 @@
 //!
 //! # Example: Enumerating MFT Entries
 //! ```no_run
-//! use usn_journal_rs::{volume::Volume, mft::Mft};
+//! use usn_journal_rs::volume::Volume;
 //!
-//! let drive_letter = 'C';
-//! let volume = Volume::from_drive_letter(drive_letter).unwrap();
-//! let mft = Mft::new(&volume);
-//! for result in mft.try_iter().unwrap().take(10) {
+//! let volume = Volume::from_drive_letter('C').unwrap();
+//! for result in volume.mft().try_iter().unwrap().take(10) {
 //!     match result {
-//!         Ok(entry) => println!("MFT entry: {entry:?}"),
+//!         Ok(entry) => println!("MFT entry: {entry}"),
 //!         Err(e) => eprintln!("Error reading MFT entry: {e}"),
 //!     }
 //! }
@@ -51,6 +47,7 @@
 //! ## License
 //! MIT License. See [LICENSE](https://github.com/wangfu91/usn-journal-rs/blob/main/LICENSE).
 
+mod display;
 pub mod errors;
 mod file_attributes;
 pub mod journal;
@@ -72,10 +69,10 @@ pub type UsnResult<T> = std::result::Result<T, UsnError>;
 pub mod prelude {
     pub use crate::{
         Fid, FileAttributes, Filetime, Usn, UsnError, UsnReason, UsnResult, UsnSourceInfo,
-        journal::UsnJournal,
-        mft::Mft,
+        journal::{JournalIterOptions, UsnEntry, UsnJournal},
+        mft::{Mft, MftEntry, MftIterOptions, UsnRecordVersion},
         path::PathResolver,
-        raw_mft::{RawMft, RawMftPathResolver},
+        raw_mft::{RawMft, RawMftEntry, RawMftPathResolver, RawMftScanOptions},
         volume::Volume,
     };
 }
@@ -111,6 +108,13 @@ mod tests {
         accepts::<prelude::UsnReason>();
         accepts::<prelude::FileAttributes>();
         accepts::<prelude::UsnSourceInfo>();
+        accepts::<prelude::UsnEntry>();
+        accepts::<prelude::MftEntry>();
+        accepts::<prelude::RawMftEntry>();
+        accepts::<prelude::JournalIterOptions>();
+        accepts::<prelude::MftIterOptions>();
+        accepts::<prelude::RawMftScanOptions>();
+        accepts::<prelude::UsnRecordVersion>();
 
         let result: prelude::UsnResult<()> = Ok(());
         assert!(result.is_ok());

--- a/src/mft/entry.rs
+++ b/src/mft/entry.rs
@@ -52,6 +52,55 @@ impl MftEntry {
     pub fn is_hidden(&self) -> bool {
         <Self as FileAttributeView>::has_hidden_attribute(self)
     }
+
+    /// Returns true if this entry is marked read-only.
+    #[must_use]
+    #[inline]
+    pub fn is_read_only(&self) -> bool {
+        self.file_attributes.is_read_only()
+    }
+
+    /// Returns true if this entry has the system attribute set.
+    #[must_use]
+    #[inline]
+    pub fn is_system(&self) -> bool {
+        self.file_attributes.is_system()
+    }
+
+    /// Returns true if this entry has the archive attribute set.
+    #[must_use]
+    #[inline]
+    pub fn is_archive(&self) -> bool {
+        self.file_attributes.is_archive()
+    }
+
+    /// Returns true if this entry is a reparse point (symlink, junction, mount point, ...).
+    #[must_use]
+    #[inline]
+    pub fn is_reparse_point(&self) -> bool {
+        self.file_attributes.is_reparse_point()
+    }
+
+    /// Returns true if this entry is stored compressed on disk.
+    #[must_use]
+    #[inline]
+    pub fn is_compressed(&self) -> bool {
+        self.file_attributes.is_compressed()
+    }
+
+    /// Returns true if this entry is stored encrypted on disk.
+    #[must_use]
+    #[inline]
+    pub fn is_encrypted(&self) -> bool {
+        self.file_attributes.is_encrypted()
+    }
+
+    /// Returns true if this entry contains sparse data.
+    #[must_use]
+    #[inline]
+    pub fn is_sparse(&self) -> bool {
+        self.file_attributes.is_sparse()
+    }
 }
 
 impl FileAttributeView for MftEntry {

--- a/src/mft/iter.rs
+++ b/src/mft/iter.rs
@@ -50,7 +50,6 @@ impl MftIter {
         high_usn: i64,
         max_usn_record_version: u16,
         buffer: Vec<u8>,
-        next_start_fid: u64,
     ) -> Self {
         Self {
             volume_handle,
@@ -60,7 +59,10 @@ impl MftIter {
             buffer,
             bytes_read: 0,
             offset: 0,
-            next_start_fid,
+            // Enumeration always starts at file reference number 0; the kernel
+            // returns the cursor for the next call as the first 8 bytes of each
+            // output buffer. The USN range is filtered via `low_usn`/`high_usn`.
+            next_start_fid: 0,
         }
     }
 

--- a/src/mft/mft.rs
+++ b/src/mft/mft.rs
@@ -39,7 +39,17 @@ impl<'a> Mft<'a> {
             options.high_usn.get(),
             options.max_usn_record_version.as_u16(),
             vec![0u8; options.buffer_bytes.get()],
-            options.low_usn.get() as u64,
         ))
+    }
+}
+
+impl Volume {
+    /// Create an [`Mft`] enumerator for this volume.
+    ///
+    /// Convenience for [`Mft::new`], so you can write
+    /// `volume.mft().try_iter()?` without importing [`Mft`].
+    #[must_use]
+    pub fn mft(&self) -> Mft<'_> {
+        Mft::new(self)
     }
 }

--- a/src/mft/options.rs
+++ b/src/mft/options.rs
@@ -100,3 +100,37 @@ impl MftIterOptionsBuilder {
         self.inner
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_spans_full_usn_range_and_allows_v3() {
+        let opts = MftIterOptions::default();
+        assert_eq!(opts.low_usn, Usn::new(0));
+        assert_eq!(opts.high_usn, Usn::new(i64::MAX));
+        assert_eq!(opts.max_usn_record_version, UsnRecordVersion::V3);
+    }
+
+    #[test]
+    fn usn_record_version_maps_to_major_version() {
+        assert_eq!(UsnRecordVersion::V2.as_u16(), 2);
+        assert_eq!(UsnRecordVersion::V3.as_u16(), 3);
+    }
+
+    #[test]
+    fn builder_round_trips_values() {
+        let opts = MftIterOptions::builder()
+            .low_usn(Usn::new(10))
+            .high_usn(Usn::new(20))
+            .max_usn_record_version(UsnRecordVersion::V2)
+            .buffer_bytes(NonZeroUsize::new(4 * 1024).unwrap())
+            .build();
+
+        assert_eq!(opts.low_usn, Usn::new(10));
+        assert_eq!(opts.high_usn, Usn::new(20));
+        assert_eq!(opts.max_usn_record_version, UsnRecordVersion::V2);
+        assert_eq!(opts.buffer_bytes.get(), 4 * 1024);
+    }
+}

--- a/src/mft/tests.rs
+++ b/src/mft/tests.rs
@@ -234,6 +234,28 @@ mod entry {
     }
 }
 
+#[test]
+fn mft_entry_attribute_predicates_delegate_to_file_attributes() {
+    use crate::FileAttributes;
+
+    let entry = MftEntry {
+        usn: Usn::new(1),
+        fid: crate::Fid::new(0x10),
+        parent_fid: crate::Fid::new(0x5),
+        file_name: std::ffi::OsString::from("link"),
+        file_attributes: FileAttributes::REPARSE_POINT
+            | FileAttributes::COMPRESSED
+            | FileAttributes::READ_ONLY,
+    };
+
+    assert!(entry.is_reparse_point());
+    assert!(entry.is_compressed());
+    assert!(entry.is_read_only());
+    assert!(!entry.is_encrypted());
+    assert!(!entry.is_dir());
+    assert!(!entry.is_sparse());
+}
+
 // Simplified mocked test using Injectorpp
 mod mocked {
     use super::*;

--- a/src/path/in_memory_tree.rs
+++ b/src/path/in_memory_tree.rs
@@ -15,11 +15,6 @@ use std::{
 /// NTFS root directory MFT record number (`$Root`).
 const NTFS_ROOT_RECORD_NUMBER: u64 = 5;
 
-/// Mask a standard 64-bit NTFS file reference down to its 48-bit record number.
-fn mask_fid_to_record_number(fid: Fid) -> Option<u64> {
-    fid.record_number()
-}
-
 /// Directory entry in the in-memory tree. Stores the parent file
 /// reference number (full 64-bit, not masked) and the leaf name as raw
 /// UTF-16 units so we don't pay an `OsString` allocation per entry.
@@ -67,7 +62,7 @@ impl InMemoryDirTree {
             if entry.file_name.is_empty() {
                 continue;
             }
-            let Some(key) = mask_fid_to_record_number(entry.file_reference) else {
+            let Some(key) = entry.file_reference.record_number() else {
                 continue;
             };
             // Encode the file name as raw UTF-16 once and store it.
@@ -143,7 +138,7 @@ impl InMemoryDirTree {
         const MAX_STEPS: usize = 256;
 
         let mut chain: Vec<&[u16]> = Vec::with_capacity(32);
-        let mut current = mask_fid_to_record_number(fid)?;
+        let mut current = fid.record_number()?;
         let mut visited = FxHashSet::default();
         let mut steps = 0usize;
         loop {
@@ -155,7 +150,7 @@ impl InMemoryDirTree {
             let entry = self.entries.get(&current)?;
             chain.push(&entry.name);
 
-            let parent = mask_fid_to_record_number(entry.parent)?;
+            let parent = entry.parent.record_number()?;
             // Stop at the NTFS root (`$Root`) or on a self-parenting record.
             if parent == current || parent == NTFS_ROOT_RECORD_NUMBER {
                 break;

--- a/src/path/resolver.rs
+++ b/src/path/resolver.rs
@@ -38,15 +38,16 @@ const DEFAULT_DIRECTORY_CACHE_CAPACITY: NonZeroUsize = unsafe {
 /// For raw-`$MFT` snapshot resolution, use
 /// [`crate::raw_mft::RawMft::path_resolver`] instead.
 ///
-/// `PathResolver` is intentionally `!Sync` — it carries an internal scratch
-/// buffer accessed via interior mutability to keep the public `resolve_path`
-/// signature ergonomic.
+/// [`resolve_path`](Self::resolve_path) takes `&self`: the directory cache and
+/// scratch buffer are held behind interior mutability, so a single resolver can
+/// be shared across an iteration loop without a `mut` binding. `PathResolver` is
+/// intentionally `!Sync` because that interior state is not synchronized.
 #[derive(Debug)]
 pub struct PathResolver<'a> {
     /// Volume on which file IDs will be resolved.
     volume: &'a Volume,
     /// Optional cache of previously resolved directory paths.
-    pub(super) dir_fid_path_cache: Option<DirLruCache>,
+    pub(super) dir_fid_path_cache: RefCell<Option<DirLruCache>>,
     /// Reusable heap buffer for `GetFileInformationByHandleEx` calls.
     buffer: RefCell<Vec<u8>>,
 }
@@ -63,7 +64,7 @@ impl<'a> PathResolver<'a> {
     pub fn new(volume: &'a Volume) -> Self {
         Self {
             volume,
-            dir_fid_path_cache: Some(LruCache::new(DEFAULT_DIRECTORY_CACHE_CAPACITY)),
+            dir_fid_path_cache: RefCell::new(Some(LruCache::new(DEFAULT_DIRECTORY_CACHE_CAPACITY))),
             buffer: RefCell::new(Vec::new()),
         }
     }
@@ -78,18 +79,23 @@ impl<'a> PathResolver<'a> {
     /// cache capacity.
     #[must_use]
     pub fn with_directory_cache(mut self, capacity: usize) -> Self {
-        self.dir_fid_path_cache = NonZeroUsize::new(capacity).map(LruCache::new);
+        self.dir_fid_path_cache = RefCell::new(NonZeroUsize::new(capacity).map(LruCache::new));
         self
     }
 
     /// Resolve `entry` to its current on-disk path, using the directory cache
     /// when configured and falling back to `OpenFileById` syscalls.
     ///
+    /// Takes `&self`: the cache and scratch buffer are updated through interior
+    /// mutability, so the same resolver can be reused across an iterator without
+    /// a `mut` binding.
+    ///
     /// Standard 64-bit NTFS IDs and extended 128-bit IDs (for example ReFS
     /// `USN_RECORD_V3` entries) are both resolved via the live volume.
     #[must_use]
-    pub fn resolve_path<E: PathResolvableEntry + ?Sized>(&mut self, entry: &E) -> Option<PathBuf> {
-        if let Some(cache) = &mut self.dir_fid_path_cache {
+    pub fn resolve_path<E: PathResolvableEntry + ?Sized>(&self, entry: &E) -> Option<PathBuf> {
+        let mut cache_guard = self.dir_fid_path_cache.borrow_mut();
+        if let Some(cache) = cache_guard.as_mut() {
             resolve_path_with_cache(
                 self.volume,
                 entry.fid(),
@@ -100,6 +106,7 @@ impl<'a> PathResolver<'a> {
                 &self.buffer,
             )
         } else {
+            drop(cache_guard);
             resolve_path(
                 self.volume,
                 entry.fid(),
@@ -108,5 +115,17 @@ impl<'a> PathResolver<'a> {
                 &self.buffer,
             )
         }
+    }
+}
+
+impl Volume {
+    /// Create a live [`PathResolver`] for this volume.
+    ///
+    /// Convenience for [`PathResolver::new`] (includes the default directory
+    /// cache). For raw-`$MFT` snapshot resolution, use
+    /// [`RawMft::path_resolver`](crate::raw_mft::RawMft::path_resolver) instead.
+    #[must_use]
+    pub fn path_resolver(&self) -> PathResolver<'_> {
+        PathResolver::new(self)
     }
 }

--- a/src/path/tests.rs
+++ b/src/path/tests.rs
@@ -177,11 +177,11 @@ fn in_memory_tree_fid_with_sequence_bits_is_masked() {
 #[test]
 fn resolve_path_with_cache_hit() {
     let volume = create_mock_volume();
-    let mut resolver = PathResolver::new(&volume).with_directory_cache(4096);
+    let resolver = PathResolver::new(&volume).with_directory_cache(4096);
 
     let cached_path = arc_path("C:\\Documents\\Folder");
     let cached_name = OsString::from("test.txt");
-    if let Some(ref mut cache) = resolver.dir_fid_path_cache {
+    if let Some(cache) = resolver.dir_fid_path_cache.borrow_mut().as_mut() {
         cache.put(
             Fid::new(0x123456),
             (Arc::clone(&cached_path), cached_name.clone()),
@@ -204,11 +204,11 @@ fn resolve_path_with_cache_hit() {
 #[test]
 fn resolve_path_with_cache_miss_parent_hit() {
     let volume = create_mock_volume();
-    let mut resolver = PathResolver::new(&volume).with_directory_cache(4096);
+    let resolver = PathResolver::new(&volume).with_directory_cache(4096);
 
     let cached_parent_path = arc_path("C:\\Documents");
     let cached_parent_name = OsString::from("Documents");
-    if let Some(ref mut cache) = resolver.dir_fid_path_cache {
+    if let Some(cache) = resolver.dir_fid_path_cache.borrow_mut().as_mut() {
         cache.put(Fid::new(0x654321), (cached_parent_path, cached_parent_name));
     }
 
@@ -228,11 +228,11 @@ fn resolve_path_with_cache_miss_parent_hit() {
 #[test]
 fn resolve_path_with_cache_directory_caching() {
     let volume = create_mock_volume();
-    let mut resolver = PathResolver::new(&volume).with_directory_cache(4096);
+    let resolver = PathResolver::new(&volume).with_directory_cache(4096);
 
     let cached_parent_path = arc_path("C:\\Documents");
     let cached_parent_name = OsString::from("Documents");
-    if let Some(ref mut cache) = resolver.dir_fid_path_cache {
+    if let Some(cache) = resolver.dir_fid_path_cache.borrow_mut().as_mut() {
         cache.put(Fid::new(0x654321), (cached_parent_path, cached_parent_name));
     }
 
@@ -248,7 +248,7 @@ fn resolve_path_with_cache_directory_caching() {
     let path = result.expect("directory should resolve");
     assert_eq!(path.to_string_lossy(), "C:\\Documents\\NewFolder");
 
-    if let Some(ref cache) = resolver.dir_fid_path_cache {
+    if let Some(cache) = resolver.dir_fid_path_cache.borrow().as_ref() {
         assert!(cache.peek(&Fid::new(0x123456)).is_some());
         let (cached_path, cached_name) = cache.peek(&Fid::new(0x123456)).unwrap();
         assert_eq!(&**cached_path, path.as_path());
@@ -259,17 +259,17 @@ fn resolve_path_with_cache_directory_caching() {
 #[test]
 fn resolve_path_with_cache_name_mismatch() {
     let volume = create_mock_volume();
-    let mut resolver = PathResolver::new(&volume).with_directory_cache(4096);
+    let resolver = PathResolver::new(&volume).with_directory_cache(4096);
 
     let cached_path = arc_path("C:\\Documents\\OldName");
     let cached_old_name = OsString::from("OldName");
-    if let Some(ref mut cache) = resolver.dir_fid_path_cache {
+    if let Some(cache) = resolver.dir_fid_path_cache.borrow_mut().as_mut() {
         cache.put(Fid::new(0x123456), (cached_path, cached_old_name));
     }
 
     let cached_parent_path = arc_path("C:\\Documents");
     let cached_parent_name = OsString::from("Documents");
-    if let Some(ref mut cache) = resolver.dir_fid_path_cache {
+    if let Some(cache) = resolver.dir_fid_path_cache.borrow_mut().as_mut() {
         cache.put(Fid::new(0x654321), (cached_parent_path, cached_parent_name));
     }
 
@@ -285,7 +285,7 @@ fn resolve_path_with_cache_name_mismatch() {
     let path = result.expect("name mismatch should refresh cache");
     assert_eq!(path.to_string_lossy(), "C:\\Documents\\NewName");
 
-    if let Some(ref cache) = resolver.dir_fid_path_cache {
+    if let Some(cache) = resolver.dir_fid_path_cache.borrow().as_ref() {
         let (updated_path, updated_name) = cache.peek(&Fid::new(0x123456)).unwrap();
         assert_eq!(updated_path.to_string_lossy(), "C:\\Documents\\NewName");
         assert_eq!(updated_name, &OsString::from("NewName"));
@@ -295,7 +295,7 @@ fn resolve_path_with_cache_name_mismatch() {
 #[test]
 fn resolve_path_failure() {
     let volume = create_mock_volume();
-    let mut resolver = PathResolver::new(&volume);
+    let resolver = PathResolver::new(&volume);
 
     let entry = MockEntry {
         fid: Fid::new(0x123456),
@@ -312,28 +312,29 @@ fn resolve_path_failure() {
 fn resolver_default_has_directory_cache_and_no_tree() {
     let volume = create_mock_volume();
     let resolver = PathResolver::new(&volume);
-    assert!(resolver.dir_fid_path_cache.is_some());
+    assert!(resolver.dir_fid_path_cache.borrow().is_some());
 }
 
 #[test]
 fn resolver_without_directory_cache_disables_cache() {
     let volume = create_mock_volume();
     let resolver = PathResolver::new(&volume).with_directory_cache(0);
-    assert!(resolver.dir_fid_path_cache.is_none());
+    assert!(resolver.dir_fid_path_cache.borrow().is_none());
 }
 
 #[test]
 fn builder_with_directory_cache_sets_cache() {
     let volume = create_mock_volume();
     let resolver = PathResolver::new(&volume).with_directory_cache(64);
-    assert!(resolver.dir_fid_path_cache.is_some());
+    assert!(resolver.dir_fid_path_cache.borrow().is_some());
 }
 
 #[test]
 fn builder_directory_cache_respects_capacity() {
     let volume = create_mock_volume();
     let resolver = PathResolver::new(&volume).with_directory_cache(8);
-    let cache = resolver.dir_fid_path_cache.as_ref().unwrap();
+    let cache = resolver.dir_fid_path_cache.borrow();
+    let cache = cache.as_ref().unwrap();
     assert_eq!(cache.cap(), NonZeroUsize::new(8).unwrap());
 }
 
@@ -343,7 +344,8 @@ fn builder_with_directory_cache_twice_keeps_last() {
     let resolver = PathResolver::new(&volume)
         .with_directory_cache(32)
         .with_directory_cache(128);
-    let cache = resolver.dir_fid_path_cache.as_ref().unwrap();
+    let cache = resolver.dir_fid_path_cache.borrow();
+    let cache = cache.as_ref().unwrap();
     assert_eq!(cache.cap(), NonZeroUsize::new(128).unwrap());
 }
 

--- a/src/raw_mft/attr_list.rs
+++ b/src/raw_mft/attr_list.rs
@@ -587,4 +587,132 @@ mod tests {
         assert_eq!(links[0].parent_reference, Fid::new(5));
         assert_eq!(links[1].parent_reference, Fid::new(9));
     }
+
+    #[test]
+    fn merged_links_returns_none_without_extension_contribution() {
+        let base_name = OsString::from("base.txt");
+        // The extension record carries neither boxed links nor an inline name,
+        // so there is nothing to merge.
+        let result = merged_links(
+            LinkView {
+                links: &[],
+                parent_reference: Fid::new(5),
+                namespace: FileNameNamespace::Win32,
+                file_name: base_name.as_os_str(),
+            },
+            LinkView {
+                links: &[],
+                parent_reference: Fid::new(9),
+                namespace: FileNameNamespace::Win32,
+                file_name: std::ffi::OsStr::new(""),
+            },
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn collect_extension_records_selects_by_wanted_type() {
+        let base_record = 42;
+        let mut data = Vec::new();
+        data.extend_from_slice(&attr_list_entry(NtfsAttributeType::FileName as u32, 100));
+        data.extend_from_slice(&attr_list_entry(NtfsAttributeType::Data as u32, 100));
+        data.extend_from_slice(&attr_list_entry(NtfsAttributeType::Data as u32, 101));
+
+        // Wanting Data pulls in both data-bearing records, deduplicating 100.
+        let records = collect_extension_records(&data, base_record, |type_id| {
+            type_id == NtfsAttributeType::Data as u32
+        });
+        assert_eq!(records, vec![100, 101]);
+    }
+
+    fn complete_entry() -> RawMftEntry {
+        RawMftEntry {
+            record_number: 10,
+            sequence_number: 1,
+            file_reference: Fid::new(10),
+            parent_reference: Fid::new(5),
+            base_record_reference: 0,
+            hard_link_count: 1,
+            flags: 0,
+            is_used: true,
+            is_directory: false,
+            is_reparse_point: false,
+            reparse_tag: None,
+            namespace: FileNameNamespace::Win32,
+            file_name: OsString::from("file.txt"),
+            si_created: crate::Filetime::new(0),
+            si_modified: crate::Filetime::new(0),
+            si_mft_modified: crate::Filetime::new(0),
+            si_accessed: crate::Filetime::new(0),
+            si_file_attributes: crate::FileAttributes::empty(),
+            fn_created: crate::Filetime::new(0),
+            fn_modified: crate::Filetime::new(0),
+            fn_mft_modified: crate::Filetime::new(0),
+            fn_accessed: crate::Filetime::new(0),
+            real_size: 0,
+            allocated_size: 0,
+            has_unnamed_data: true,
+            is_resident: true,
+            is_sparse: false,
+            is_compressed: false,
+            is_encrypted: false,
+            data_run_summary: None,
+            alternate_data_streams: Box::default(),
+            links: Box::default(),
+        }
+    }
+
+    #[test]
+    fn complete_entry_needs_no_enrichment() {
+        assert!(!should_enrich_from_attr_list(&complete_entry()));
+    }
+
+    #[test]
+    fn multiple_hard_links_need_file_name_enrichment() {
+        let mut entry = complete_entry();
+        entry.hard_link_count = 2;
+        assert!(raw_entry_enrichment_needs(&entry).file_name);
+        assert!(should_enrich_from_attr_list(&entry));
+    }
+
+    #[test]
+    fn non_win32_namespace_needs_file_name_enrichment() {
+        let mut entry = complete_entry();
+        entry.namespace = FileNameNamespace::Posix;
+        assert!(raw_entry_enrichment_needs(&entry).file_name);
+    }
+
+    #[test]
+    fn empty_name_needs_file_name_enrichment() {
+        let mut entry = complete_entry();
+        entry.file_name = OsString::new();
+        assert!(raw_entry_enrichment_needs(&entry).file_name);
+    }
+
+    #[test]
+    fn file_without_unnamed_data_needs_data_enrichment() {
+        let mut entry = complete_entry();
+        entry.has_unnamed_data = false;
+        assert!(raw_entry_enrichment_needs(&entry).data);
+    }
+
+    #[test]
+    fn directory_without_data_needs_no_data_enrichment() {
+        let mut entry = complete_entry();
+        entry.is_directory = true;
+        entry.has_unnamed_data = false;
+        let needs = raw_entry_enrichment_needs(&entry);
+        assert!(!needs.data, "directories never need $DATA enrichment");
+    }
+
+    #[test]
+    fn reparse_without_tag_needs_reparse_enrichment() {
+        let mut entry = complete_entry();
+        entry.is_reparse_point = true;
+        entry.reparse_tag = None;
+        let needs = raw_entry_enrichment_needs(&entry);
+        assert!(needs.reparse);
+        assert!(!needs.file_name);
+        assert!(!needs.data);
+    }
 }

--- a/src/raw_mft/bootstrap/discovery.rs
+++ b/src/raw_mft/bootstrap/discovery.rs
@@ -140,3 +140,79 @@ fn decode_nonresident_runs(attr: &NtfsAttribute<'_>, label: &'static str) -> Opt
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raw_mft::layout::attribute::{
+        NtfsAttributeHeader, NtfsAttributeType, NtfsNonResidentAttributeHeader,
+    };
+    use std::mem::size_of;
+    use zerocopy::IntoBytes;
+
+    /// Build a non-resident `$DATA` attribute whose runlist starts at
+    /// `data_runs_offset` and is followed by `runlist` bytes.
+    fn build_nonresident_attr(data_runs_offset: u16, runlist: &[u8]) -> Vec<u8> {
+        let header_size = size_of::<NtfsNonResidentAttributeHeader>();
+        let total = header_size + runlist.len();
+        let header = NtfsNonResidentAttributeHeader {
+            attribute_header: NtfsAttributeHeader {
+                type_id: NtfsAttributeType::Data as u32,
+                length: total as u32,
+                is_non_resident: 1,
+                name_length: 0,
+                name_offset: 0,
+                flags: 0,
+                id: 0,
+            },
+            lowest_vcn: 0,
+            highest_vcn: 0,
+            data_runs_offset,
+            compression_unit_exponent: 0,
+            _reserved: [0; 5],
+            allocated_size: 0,
+            data_size: 0,
+            initialized_size: 0,
+        };
+        let mut buf = vec![0u8; total];
+        buf[..header_size].copy_from_slice(header.as_bytes());
+        buf[header_size..].copy_from_slice(runlist);
+        buf
+    }
+
+    #[test]
+    fn decodes_valid_nonresident_runlist() {
+        let header_size = size_of::<NtfsNonResidentAttributeHeader>();
+        // Single run: 0x21 length=5, offset=0x0234 -> LCN 564.
+        let buf = build_nonresident_attr(header_size as u16, &[0x21, 0x05, 0x34, 0x02, 0x00]);
+        let attr = NtfsAttribute::new(&buf).expect("attr");
+        let runs = decode_nonresident_runs(&attr, "$TEST").expect("runs");
+        assert_eq!(
+            runs,
+            vec![DataRun::Data {
+                lcn: 564,
+                clusters: 5
+            }]
+        );
+    }
+
+    #[test]
+    fn returns_none_when_runs_offset_past_attribute() {
+        let header_size = size_of::<NtfsNonResidentAttributeHeader>();
+        let runlist = [0x21u8, 0x05, 0x34, 0x02, 0x00];
+        let total = header_size + runlist.len();
+        // data_runs_offset points beyond the attribute's own bytes.
+        let buf = build_nonresident_attr((total + 10) as u16, &runlist);
+        let attr = NtfsAttribute::new(&buf).expect("attr");
+        assert!(decode_nonresident_runs(&attr, "$TEST").is_none());
+    }
+
+    #[test]
+    fn returns_none_for_undecodable_runlist() {
+        let header_size = size_of::<NtfsNonResidentAttributeHeader>();
+        // Truncated run: header byte promises offset bytes that are absent.
+        let buf = build_nonresident_attr(header_size as u16, &[0x21, 0x05]);
+        let attr = NtfsAttribute::new(&buf).expect("attr");
+        assert!(decode_nonresident_runs(&attr, "$TEST").is_none());
+    }
+}

--- a/src/raw_mft/chunk_plan.rs
+++ b/src/raw_mft/chunk_plan.rs
@@ -256,4 +256,99 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn empty_range_produces_no_chunks() {
+        let chunk_size = NonZeroU64::new(8).expect("non-zero");
+        assert!(build_work_chunks(5, 5, chunk_size, true, |_| true).is_empty());
+        // A start beyond the end must also produce nothing (no underflow).
+        assert!(build_work_chunks(10, 5, chunk_size, true, |_| true).is_empty());
+    }
+
+    #[test]
+    fn include_unused_keeps_fully_unused_bands() {
+        let chunk_size = NonZeroU64::new(4).expect("non-zero");
+        // Every record unused, but include_unused_records = true keeps all bands.
+        let chunks = build_work_chunks(0, 12, chunk_size, true, |_| false);
+        assert_eq!(
+            chunks,
+            vec![
+                RawMftWorkChunk {
+                    start_record: 0,
+                    end_record: 4,
+                },
+                RawMftWorkChunk {
+                    start_record: 4,
+                    end_record: 8,
+                },
+                RawMftWorkChunk {
+                    start_record: 8,
+                    end_record: 12,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn range_smaller_than_chunk_yields_single_chunk() {
+        let chunk_size = NonZeroU64::new(64).expect("non-zero");
+        let chunks = build_work_chunks(3, 9, chunk_size, true, |_| true);
+        assert_eq!(
+            chunks,
+            vec![RawMftWorkChunk {
+                start_record: 3,
+                end_record: 9,
+            }]
+        );
+    }
+
+    #[test]
+    fn work_chunk_record_len_is_saturating() {
+        assert_eq!(
+            RawMftWorkChunk {
+                start_record: 10,
+                end_record: 18,
+            }
+            .record_len(),
+            8
+        );
+        // An inverted chunk must saturate to zero rather than underflow.
+        assert_eq!(
+            RawMftWorkChunk {
+                start_record: 18,
+                end_record: 10,
+            }
+            .record_len(),
+            0
+        );
+    }
+
+    #[test]
+    fn chunk_plan_builder_round_trips_values() {
+        use crate::raw_mft::{RawMftChunkPlanOptions, RawMftRecordRange};
+
+        let options = RawMftChunkPlanOptions::builder()
+            .include_unused_records(true)
+            .range(RawMftRecordRange::new(24, Some(1024)))
+            .max_records_per_chunk(NonZeroU64::new(2048).expect("non-zero"))
+            .build();
+
+        assert!(options.include_unused_records());
+        assert_eq!(options.range().start_record(), 24);
+        assert_eq!(options.range().end_record(), Some(1024));
+        assert_eq!(
+            options.max_records_per_chunk(),
+            NonZeroU64::new(2048).expect("non-zero")
+        );
+    }
+
+    #[test]
+    fn chunk_plan_default_excludes_unused_from_first_normal_record() {
+        use crate::raw_mft::RawMftChunkPlanOptions;
+
+        let options = RawMftChunkPlanOptions::default();
+        assert!(!options.include_unused_records());
+        assert_eq!(options.range().start_record(), 24);
+        assert_eq!(options.range().end_record(), None);
+    }
 }

--- a/src/raw_mft/entry_build/capture.rs
+++ b/src/raw_mft/entry_build/capture.rs
@@ -28,11 +28,6 @@ pub(super) fn capture_attribute_list(attr: &NtfsAttribute<'_>) -> Option<Attribu
 /// Decode the reparse tag stored in a resident `$REPARSE_POINT` value.
 pub(super) fn resident_reparse_tag(attr: &NtfsAttribute<'_>) -> Option<u32> {
     let value = attr.resident_value()?;
-    let tag_bytes = value.get(..4)?;
-    Some(u32::from_le_bytes([
-        tag_bytes[0],
-        tag_bytes[1],
-        tag_bytes[2],
-        tag_bytes[3],
-    ]))
+    let tag_bytes: [u8; 4] = value.get(..4)?.try_into().ok()?;
+    Some(u32::from_le_bytes(tag_bytes))
 }

--- a/src/raw_mft/entry_build/entry.rs
+++ b/src/raw_mft/entry_build/entry.rs
@@ -1,6 +1,7 @@
 //! Rich per-record metadata extracted from a single FILE record.
 
 use std::ffi::OsString;
+use std::fmt;
 
 use log::warn;
 
@@ -14,7 +15,10 @@ use crate::{
     Fid, FileAttributes, Filetime,
     file_attributes::FileAttributeView,
     raw_mft::layout::{
-        attribute::{FileNameNamespace, NtfsAttribute, file_attr_flags, osstring_from_utf16le},
+        attribute::{
+            FileNameNamespace, NtfsAttribute, attr_header_flags, file_attr_flags,
+            osstring_from_utf16le,
+        },
         data_run::{DataRunSummary, summarize_runs},
         record::FileRecord,
     },
@@ -151,6 +155,24 @@ pub struct RawMftEntry {
     pub alternate_data_streams: Box<[AdsInfo]>,
     /// All `$FILE_NAME` links observed on this record and any loaded extension records.
     pub links: Box<[RawMftLink]>,
+}
+
+impl fmt::Display for RawMftEntry {
+    /// One-line, compact summary suitable for logging. For a full multi-line
+    /// dump, format the individual public fields.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = if self.is_directory { "DIR " } else { "FILE" };
+        write!(
+            f,
+            "raw #{} {kind} fid={} parent={} links={} size={} \"{}\"",
+            self.record_number,
+            self.file_reference,
+            self.parent_reference,
+            self.hard_link_count,
+            self.real_size,
+            self.file_name.to_string_lossy(),
+        )
+    }
 }
 
 impl RawMftEntry {
@@ -309,9 +331,9 @@ impl RawMftEntryBuilder {
             None
         };
         let attr_flags = attr.flags();
-        let is_compressed = attr_flags & 0x0001 != 0;
-        let is_encrypted = attr_flags & 0x4000 != 0;
-        let is_sparse = attr_flags & 0x8000 != 0;
+        let is_compressed = attr_flags & attr_header_flags::COMPRESSED != 0;
+        let is_encrypted = attr_flags & attr_header_flags::ENCRYPTED != 0;
+        let is_sparse = attr_flags & attr_header_flags::SPARSE != 0;
         match stream_name {
             None => {
                 if !self.have_unnamed_data {

--- a/src/raw_mft/history.rs
+++ b/src/raw_mft/history.rs
@@ -398,4 +398,93 @@ mod tests {
             ))
         );
     }
+
+    #[test]
+    fn len_and_is_empty_track_named_inserts() {
+        let mut index = HistoricalPathIndex::new();
+        assert!(index.is_empty());
+        assert_eq!(index.len(), 0);
+
+        index.insert(&sample_entry(7, 1, NTFS_ROOT_RECORD_NUMBER, 1, "dir"));
+        index.insert(&sample_entry(10, 1, 7, 1, "file.txt"));
+
+        assert!(!index.is_empty());
+        assert_eq!(index.len(), 2);
+    }
+
+    #[test]
+    fn insert_ignores_entries_without_a_name() {
+        let mut index = HistoricalPathIndex::new();
+        index.insert(&sample_entry(10, 1, 7, 1, ""));
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn insert_ignores_extended_file_ids() {
+        let mut index = HistoricalPathIndex::new();
+        let mut entry = sample_entry(10, 1, 7, 1, "refs.dat");
+        // A 128-bit ReFS-style id exposes no NTFS record number, so it cannot
+        // participate in record-number reconstruction and must be ignored.
+        entry.file_reference = Fid::from_u128(0x1_0000_0000_0000_0001);
+        index.insert(&entry);
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn resolves_deep_multi_level_path() {
+        let mut index = HistoricalPathIndex::new();
+        index.insert(&sample_entry(7, 1, NTFS_ROOT_RECORD_NUMBER, 1, "docs"));
+        index.insert(&sample_entry(10, 1, 7, 1, "alice"));
+        let file = sample_entry(20, 1, 10, 1, "file.txt");
+        index.insert(&file);
+
+        let resolved = index.resolve_entry_best_effort(&mock_volume(), &file);
+        assert_eq!(resolved.quality, HistoricalPathResolutionQuality::Exact);
+        assert_eq!(resolved.path, PathBuf::from(r"C:\docs\alice\file.txt"));
+    }
+
+    #[test]
+    fn self_parenting_record_terminates_as_complete() {
+        // A record whose parent is itself (and not the root) is treated as a
+        // terminal path component rather than looping forever.
+        let mut index = HistoricalPathIndex::new();
+        let entry = sample_entry(7, 2, 7, 2, "selfdir");
+        index.insert(&entry);
+
+        let resolved = index.resolve_entry_best_effort(&mock_volume(), &entry);
+        assert_eq!(resolved.quality, HistoricalPathResolutionQuality::Exact);
+        assert_eq!(resolved.path, PathBuf::from(r"C:\selfdir"));
+    }
+
+    #[test]
+    fn detects_cycle_in_parent_chain() {
+        // 10 -> 11 -> 10 with neither pointing at the root: the walk must break
+        // on the revisit instead of looping, yielding a partial resolution.
+        let mut index = HistoricalPathIndex::new();
+        let a = sample_entry(10, 1, 11, 1, "a");
+        let b = sample_entry(11, 1, 10, 1, "b");
+        index.insert(&a);
+        index.insert(&b);
+
+        let resolved = index.resolve_entry_best_effort(&mock_volume(), &a);
+        assert_eq!(resolved.quality, HistoricalPathResolutionQuality::Partial);
+        assert!(resolved.missing_parent.is_some());
+    }
+
+    #[test]
+    fn resolves_missing_fid_to_fallback_leaf() {
+        // Nothing is indexed, so resolving falls back to the provided leaf name
+        // behind an unresolved-parent marker.
+        let index = HistoricalPathIndex::new();
+        let orphan = standard_fid(42, 1);
+        let resolved =
+            index.resolve_best_effort(&mock_volume(), orphan, OsStr::new("orphan.txt"));
+
+        assert_eq!(resolved.quality, HistoricalPathResolutionQuality::Partial);
+        assert_eq!(resolved.missing_parent, Some(orphan));
+        assert_eq!(
+            resolved.path,
+            PathBuf::from(format!(r"C:\<unresolved-parent:{orphan}>\orphan.txt"))
+        );
+    }
 }

--- a/src/raw_mft/layout/attribute/headers.rs
+++ b/src/raw_mft/layout/attribute/headers.rs
@@ -208,3 +208,16 @@ pub mod file_attr_flags {
     /// Encrypted-file attribute bit.
     pub const ENCRYPTED: u32 = 0x4000;
 }
+
+/// Attribute-record header flag bits (`NtfsAttributeHeader::flags`).
+///
+/// These describe the on-disk stream encoding of a single attribute and are
+/// distinct from the file-level [`file_attr_flags`].
+pub mod attr_header_flags {
+    /// Stream data is compressed.
+    pub const COMPRESSED: u16 = 0x0001;
+    /// Stream data is encrypted.
+    pub const ENCRYPTED: u16 = 0x4000;
+    /// Stream data is sparse.
+    pub const SPARSE: u16 = 0x8000;
+}

--- a/src/raw_mft/layout/attribute/iter.rs
+++ b/src/raw_mft/layout/attribute/iter.rs
@@ -161,4 +161,68 @@ mod tests {
             vec![(NtfsAttributeType::FileName as u32, 0x0001_0000_0000_0042)]
         );
     }
+
+    fn attr_list_entry(type_id: u32, file_reference: u64) -> Vec<u8> {
+        let min = size_of::<AttributeListEntryHeader>();
+        let header = AttributeListEntryHeader {
+            type_id,
+            record_length: min as u16,
+            attribute_name_length: 0,
+            attribute_name_offset: 0,
+            lowest_vcn: 0,
+            file_reference,
+            attribute_id: 0,
+        };
+        header.as_bytes().to_vec()
+    }
+
+    #[test]
+    fn iterates_multiple_attribute_list_entries() {
+        let mut bytes = attr_list_entry(NtfsAttributeType::StandardInformation as u32, 0x11);
+        bytes.extend(attr_list_entry(NtfsAttributeType::Data as u32, 0x22));
+
+        let mut seen = Vec::new();
+        for_each_attr_list_entry(&bytes, |type_id, file_reference| {
+            seen.push((type_id, file_reference));
+        });
+
+        assert_eq!(
+            seen,
+            vec![
+                (NtfsAttributeType::StandardInformation as u32, 0x11),
+                (NtfsAttributeType::Data as u32, 0x22),
+            ]
+        );
+    }
+
+    #[test]
+    fn attr_list_stops_at_zero_length_entry() {
+        let mut bytes = attr_list_entry(NtfsAttributeType::FileName as u32, 0x42);
+        // A second entry that declares record_length = 0 must halt iteration.
+        let mut malformed = attr_list_entry(NtfsAttributeType::Data as u32, 0x99);
+        malformed[4..6].copy_from_slice(&0u16.to_le_bytes()); // record_length = 0
+        bytes.extend(malformed);
+
+        let mut seen = Vec::new();
+        for_each_attr_list_entry(&bytes, |type_id, file_reference| {
+            seen.push((type_id, file_reference));
+        });
+
+        assert_eq!(seen, vec![(NtfsAttributeType::FileName as u32, 0x42)]);
+    }
+
+    #[test]
+    fn attribute_iteration_respects_used_size() {
+        let mut buf = vec![0u8; 512];
+        let a1 = build_resident_attr(NtfsAttributeType::StandardInformation as u32, &[0u8; 48]);
+        buf[..a1.len()].copy_from_slice(&a1);
+        let a2 = build_resident_attr(NtfsAttributeType::Data as u32, &[1, 2, 3, 4]);
+        buf[a1.len()..a1.len() + a2.len()].copy_from_slice(&a2);
+
+        // used_size covers only the first attribute, so the second must be
+        // ignored even though it is present in the buffer.
+        let mut seen = Vec::new();
+        for_each_attribute(&buf, 0, a1.len(), |a| seen.push(a.type_id()));
+        assert_eq!(seen, vec![NtfsAttributeType::StandardInformation as u32]);
+    }
 }

--- a/src/raw_mft/layout/attribute/mod.rs
+++ b/src/raw_mft/layout/attribute/mod.rs
@@ -13,7 +13,7 @@ pub use headers::FileNameNamespace;
 pub(crate) use headers::{
     AttributeListEntryHeader, NtfsAttributeHeader, NtfsAttributeType, NtfsFileNameHeader,
     NtfsNonResidentAttributeHeader, NtfsResidentAttributeHeader, NtfsStandardInformation,
-    file_attr_flags,
+    attr_header_flags, file_attr_flags,
 };
 pub(crate) use iter::{for_each_attr_list_entry, for_each_attribute};
 pub(crate) use view::{NtfsAttribute, osstring_from_utf16le};

--- a/src/raw_mft/layout/attribute/view.rs
+++ b/src/raw_mft/layout/attribute/view.rs
@@ -292,4 +292,80 @@ mod tests {
         buf[4..8].copy_from_slice(&0u32.to_le_bytes());
         assert!(NtfsAttribute::new(&buf).is_none());
     }
+
+    #[test]
+    fn parses_non_resident_header() {
+        let header_size = size_of::<NtfsNonResidentAttributeHeader>();
+        let total = header_size + 4; // room for a tiny run list
+        let header = NtfsNonResidentAttributeHeader {
+            attribute_header: NtfsAttributeHeader {
+                type_id: NtfsAttributeType::Data as u32,
+                length: total as u32,
+                is_non_resident: 1,
+                name_length: 0,
+                name_offset: 0,
+                flags: 0,
+                id: 0,
+            },
+            lowest_vcn: 0,
+            highest_vcn: 1,
+            data_runs_offset: header_size as u16,
+            compression_unit_exponent: 0,
+            _reserved: [0; 5],
+            allocated_size: 8192,
+            data_size: 12345,
+            initialized_size: 12345,
+        };
+        let mut buf = vec![0u8; total];
+        buf[..header_size].copy_from_slice(header.as_bytes());
+
+        let attr = NtfsAttribute::new(&buf).expect("attr");
+        assert!(attr.is_non_resident());
+        assert!(attr.resident_header().is_none());
+        let nr = attr.nonresident_header().expect("non-resident header");
+        let data_size = nr.data_size;
+        let allocated_size = nr.allocated_size;
+        let runs_offset = nr.data_runs_offset;
+        assert_eq!(data_size, 12345);
+        assert_eq!(allocated_size, 8192);
+        assert_eq!(runs_offset as usize, header_size);
+    }
+
+    #[test]
+    fn reads_named_attribute_name_bytes() {
+        let header_size = size_of::<NtfsResidentAttributeHeader>();
+        let name: Vec<u16> = "ads".encode_utf16().collect();
+        let name_bytes_len = name.len() * 2;
+        let total = header_size + name_bytes_len;
+
+        let header = NtfsResidentAttributeHeader {
+            attribute_header: NtfsAttributeHeader {
+                type_id: NtfsAttributeType::Data as u32,
+                length: total as u32,
+                is_non_resident: 0,
+                name_length: name.len() as u8,
+                name_offset: header_size as u16,
+                flags: 0,
+                id: 0,
+            },
+            value_length: 0,
+            value_offset: total as u16,
+            indexed_flag: 0,
+            _pad: 0,
+        };
+        let mut buf = vec![0u8; total];
+        buf[..header_size].copy_from_slice(header.as_bytes());
+        for (i, unit) in name.iter().enumerate() {
+            let off = header_size + i * 2;
+            buf[off..off + 2].copy_from_slice(&unit.to_le_bytes());
+        }
+
+        let attr = NtfsAttribute::new(&buf).expect("attr");
+        assert!(attr.has_name());
+        let raw_name = attr.name_bytes().expect("name bytes");
+        assert_eq!(
+            osstring_from_utf16le(raw_name).expect("decode"),
+            std::ffi::OsString::from("ads")
+        );
+    }
 }

--- a/src/raw_mft/layout/boot.rs
+++ b/src/raw_mft/layout/boot.rs
@@ -258,4 +258,74 @@ mod tests {
             Err(UsnError::InvalidBootSector(_))
         ));
     }
+
+    #[test]
+    fn parses_negative_sectors_per_cluster_encoding() {
+        // sectors_per_cluster = -12 encodes a 2^12 = 4096-byte cluster directly,
+        // which with a 512-byte sector is 8 sectors per cluster.
+        let buf = make_boot_sector(512, -12, 0x10_0000, 0xC_0000, 0x2, -10);
+        let bs = BootSector::parse(&buf).expect("negative spc encoding should parse");
+        assert_eq!(bs.cluster_size, 4096);
+        assert_eq!(bs.file_record_size, 1024);
+        assert_eq!(bs.mft_byte_offset, 0xC_0000 * 4096);
+    }
+
+    #[test]
+    fn rejects_non_power_of_two_bytes_per_sector() {
+        let buf = make_boot_sector(500, 8, 0, 0, 0, -10);
+        assert!(matches!(
+            BootSector::parse(&buf),
+            Err(UsnError::InvalidBootSector(
+                "bytes_per_sector must be a non-zero power of two"
+            ))
+        ));
+    }
+
+    #[test]
+    fn rejects_cluster_size_smaller_than_sector() {
+        // -8 => 2^8 = 256-byte cluster, smaller than the 512-byte sector.
+        let buf = make_boot_sector(512, -8, 0, 0, 0, -10);
+        assert!(matches!(
+            BootSector::parse(&buf),
+            Err(UsnError::InvalidBootSector(
+                "cluster size smaller than sector size"
+            ))
+        ));
+    }
+
+    #[test]
+    fn rejects_sectors_per_cluster_exponent_too_large() {
+        let buf = make_boot_sector(512, -128, 0, 0, 0, -10);
+        assert!(matches!(
+            BootSector::parse(&buf),
+            Err(UsnError::InvalidBootSector(
+                "sectors_per_cluster exponent too large"
+            ))
+        ));
+    }
+
+    #[test]
+    fn rejects_file_record_size_exponent_too_large() {
+        let buf = make_boot_sector(512, 8, 0, 0, 0, -128);
+        assert!(matches!(
+            BootSector::parse(&buf),
+            Err(UsnError::InvalidBootSector(
+                "file_record_size exponent too large"
+            ))
+        ));
+    }
+
+    #[test]
+    fn rejects_file_record_size_not_multiple_of_sector() {
+        // 1024-byte sectors, 1 sector/cluster => 1024-byte cluster.
+        // file_record_size_info = -9 => 2^9 = 512-byte records, which is a
+        // valid size but not a multiple of the 1024-byte sector.
+        let buf = make_boot_sector(1024, 1, 1000, 100, 200, -9);
+        assert!(matches!(
+            BootSector::parse(&buf),
+            Err(UsnError::InvalidBootSector(
+                "file_record_size not a multiple of bytes_per_sector"
+            ))
+        ));
+    }
 }

--- a/src/raw_mft/layout/data_run.rs
+++ b/src/raw_mft/layout/data_run.rs
@@ -244,4 +244,99 @@ mod tests {
             assert_eq!(summary_error, decode_error);
         }
     }
+
+    #[test]
+    fn lone_terminator_decodes_to_no_runs() {
+        let (runs, summary) = decode_runs(&[0x00]).expect("terminator only is valid");
+        assert!(runs.is_empty());
+        assert_eq!(summary, DataRunSummary::default());
+        assert_eq!(summarize_runs(&[0x00]).unwrap(), summary);
+    }
+
+    #[test]
+    fn empty_input_is_unterminated() {
+        let error = decode_runs(&[]).unwrap_err();
+        assert!(matches!(
+            error,
+            UsnError::InvalidDataRun("unterminated data run sequence")
+        ));
+    }
+
+    #[test]
+    fn decodes_multi_byte_length_field() {
+        // header 0x12: 2-byte length, 1-byte offset.
+        // length = 0x0100 (256 clusters), offset = 0x05 -> LCN 5.
+        let runs = [0x12u8, 0x00, 0x01, 0x05, 0x00];
+        let (decoded, summary) = decode_runs(&runs).expect("valid multi-byte length run");
+        assert_eq!(
+            decoded,
+            vec![DataRun::Data {
+                lcn: 5,
+                clusters: 256
+            }]
+        );
+        assert_eq!(summary.total_clusters, 256);
+    }
+
+    #[test]
+    fn decodes_eight_byte_offset_field() {
+        // header 0x81: 1-byte length, 8-byte offset.
+        // clusters = 2, LCN = 0x1234_5678.
+        let runs = [
+            0x81u8, 0x02, 0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let (decoded, _) = decode_runs(&runs).expect("valid 8-byte offset run");
+        assert_eq!(
+            decoded,
+            vec![DataRun::Data {
+                lcn: 0x1234_5678,
+                clusters: 2
+            }]
+        );
+    }
+
+    #[test]
+    fn three_byte_negative_offset_sign_extends() {
+        // First run: 0x31 len=2, offset=+0x100000 (3 bytes) -> LCN 1_048_576.
+        // Second run: 0x31 len=1, offset=-1 (0xFFFFFF, 3 bytes) -> LCN 1_048_575.
+        let runs = [
+            0x31u8, 0x02, 0x00, 0x00, 0x10, 0x31, 0x01, 0xFF, 0xFF, 0xFF, 0x00,
+        ];
+        let (decoded, summary) = decode_runs(&runs).expect("valid signed offset chain");
+        assert_eq!(
+            decoded,
+            vec![
+                DataRun::Data {
+                    lcn: 1_048_576,
+                    clusters: 2
+                },
+                DataRun::Data {
+                    lcn: 1_048_575,
+                    clusters: 1
+                },
+            ]
+        );
+        assert_eq!(summary.run_count, 2);
+        assert_eq!(summary.total_clusters, 3);
+    }
+
+    #[test]
+    fn sparse_run_does_not_shift_following_data_lcn() {
+        // Sparse hole (offset nibble 0) must not move the LCN baseline, so the
+        // following data run's delta is relative to LCN 0.
+        // 0x01 len=4 -> sparse(4); 0x21 len=2 off=0x000A -> Data{lcn:10}.
+        let runs = [0x01u8, 0x04, 0x21, 0x02, 0x0A, 0x00, 0x00];
+        let (decoded, summary) = decode_runs(&runs).expect("valid sparse-then-data chain");
+        assert_eq!(
+            decoded,
+            vec![
+                DataRun::Sparse { clusters: 4 },
+                DataRun::Data {
+                    lcn: 10,
+                    clusters: 2
+                },
+            ]
+        );
+        assert_eq!(summary.total_clusters, 6);
+    }
 }

--- a/src/raw_mft/layout/extent.rs
+++ b/src/raw_mft/layout/extent.rs
@@ -281,4 +281,45 @@ mod tests {
             Err(UsnError::InvalidDataRun("volume offset overflow"))
         ));
     }
+
+    #[test]
+    fn record_count_includes_sparse_holes() {
+        // Sparse clusters still occupy logical address space, so they count
+        // toward the number of addressable records.
+        let runs = vec![
+            DataRun::Sparse { clusters: 2 },
+            DataRun::Data {
+                lcn: 500,
+                clusters: 2,
+            },
+        ];
+        let map = ExtentMap::from_runs(&runs, 4096, 1024);
+        // 4 clusters * 4096 bytes / 1024-byte records = 16 records.
+        assert_eq!(map.record_count(), 16);
+    }
+
+    #[test]
+    fn record_count_is_zero_when_file_record_size_is_zero() {
+        let runs = vec![DataRun::Data {
+            lcn: 100,
+            clusters: 4,
+        }];
+        let map = ExtentMap::from_runs(&runs, 4096, 0);
+        assert_eq!(map.record_count(), 0);
+    }
+
+    #[test]
+    fn resolves_sub_cluster_offset_within_data_run() {
+        // Record 9 lands inside the data run (VCN 2) at a 1024-byte sub-cluster
+        // offset, exercising the intra-cluster remainder arithmetic.
+        let runs = vec![
+            DataRun::Sparse { clusters: 2 },
+            DataRun::Data {
+                lcn: 500,
+                clusters: 2,
+            },
+        ];
+        let map = ExtentMap::from_runs(&runs, 4096, 1024);
+        assert_eq!(map.record_offset(9).unwrap(), Some(500 * 4096 + 1024));
+    }
 }

--- a/src/raw_mft/layout/record.rs
+++ b/src/raw_mft/layout/record.rs
@@ -289,4 +289,49 @@ mod tests {
         bad[0] = b'X';
         assert_eq!(FileRecord::peek_base_reference(&bad), None);
     }
+
+    #[test]
+    fn is_directory_reflects_header_flag() {
+        let mut buf = build_minimal_record();
+        // flags field is a u16 at header offset 22.
+        let flags = flags::IN_USE | flags::IS_DIRECTORY;
+        buf[22..24].copy_from_slice(&flags.to_le_bytes());
+        let rec = FileRecord::parse(1, None, &mut buf).expect("parse ok");
+        assert!(rec.is_used());
+        assert!(rec.is_directory());
+    }
+
+    #[test]
+    fn attrs_range_reports_offset_and_used_size() {
+        let mut buf = build_minimal_record();
+        let rec = FileRecord::parse(1, None, &mut buf).expect("parse ok");
+        // build_minimal_record uses attributes_offset = 56, used_size = 200.
+        assert_eq!(rec.attrs_range(), (56, 200));
+    }
+
+    #[test]
+    fn file_reference_masks_record_number_and_applies_sequence() {
+        let mut buf = build_minimal_record();
+        // sequence_value is a u16 at header offset 16.
+        buf[16..18].copy_from_slice(&0xABCDu16.to_le_bytes());
+        let rec = FileRecord::parse(0x1234, None, &mut buf).expect("parse ok");
+        assert_eq!(rec.sequence_value(), 0xABCD);
+        assert_eq!(rec.file_reference(), (0xABCDu64 << 48) | 0x1234);
+    }
+
+    #[test]
+    fn rejects_zero_update_sequence_length() {
+        let mut buf = build_minimal_record();
+        // update_sequence_length is a u16 at header offset 6.
+        buf[6..8].copy_from_slice(&0u16.to_le_bytes());
+        assert!(!FileRecord::is_valid(&buf));
+    }
+
+    #[test]
+    fn rejects_attributes_offset_beyond_used_size() {
+        let mut buf = build_minimal_record();
+        // attributes_offset (offset 20) == used_size (200) is out of bounds.
+        buf[20..22].copy_from_slice(&200u16.to_le_bytes());
+        assert!(!FileRecord::is_valid(&buf));
+    }
 }

--- a/src/raw_mft/layout/usa_fixup.rs
+++ b/src/raw_mft/layout/usa_fixup.rs
@@ -222,4 +222,37 @@ mod tests {
             Err(UsnError::InvalidMftRecord { .. })
         ));
     }
+
+    #[test]
+    fn applies_fixup_for_single_sector() {
+        let replacements = [[0xAA, 0xBB]];
+        let mut buf = build_record(512, 42, [0x01, 0x00], &replacements);
+        apply_usa_fixup(3, &mut buf, 42, 2).expect("single-sector fixup ok");
+        assert_eq!(&buf[510..512], &replacements[0]);
+    }
+
+    #[test]
+    fn rejects_record_smaller_than_declared_sectors() {
+        // usa_count = 3 => 2 protected sectors => needs 1024 bytes, but the
+        // buffer is only 700, so the header is inconsistent with the record.
+        let mut buf = vec![0u8; 700];
+        match apply_usa_fixup(1, &mut buf, 42, 3) {
+            Err(UsnError::InvalidMftRecord { number: 1, reason }) => {
+                assert_eq!(reason, "record smaller than declared sector count");
+            }
+            other => panic!("expected InvalidMftRecord, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fixup_only_touches_sector_trailers() {
+        let replacements = [[0xAA, 0xBB], [0xCC, 0xDD]];
+        let mut buf = build_record(1024, 42, [0x01, 0x00], &replacements);
+        // A marker byte in the record body (not a trailer) must survive fixup.
+        buf[300] = 0x77;
+        apply_usa_fixup(7, &mut buf, 42, 3).expect("fixup ok");
+        assert_eq!(buf[300], 0x77, "non-trailer bytes must not be modified");
+        assert_eq!(&buf[510..512], &replacements[0]);
+        assert_eq!(&buf[1022..1024], &replacements[1]);
+    }
 }

--- a/src/raw_mft/mod.rs
+++ b/src/raw_mft/mod.rs
@@ -166,3 +166,13 @@ impl<'a> RawMft<'a> {
         }
     }
 }
+
+impl Volume {
+    /// Open the raw `$MFT` reader for this volume.
+    ///
+    /// Convenience for [`RawMft::new`]. NTFS only — ReFS volumes return
+    /// [`UsnError::UnsupportedFilesystem`].
+    pub fn raw_mft(&self) -> Result<RawMft<'_>, UsnError> {
+        RawMft::new(self)
+    }
+}

--- a/src/raw_mft/parallel/executor.rs
+++ b/src/raw_mft/parallel/executor.rs
@@ -273,3 +273,67 @@ fn worker_panicked(payload: Box<dyn std::any::Any + Send + 'static>) -> UsnError
         "raw_mft parallel worker panicked: {details}"
     )))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contiguous_worker_range_partitions_evenly() {
+        // 9 chunks across 3 workers: three contiguous bands of 3.
+        assert_eq!(contiguous_worker_range(9, 3, 0), (0, 3));
+        assert_eq!(contiguous_worker_range(9, 3, 1), (3, 6));
+        assert_eq!(contiguous_worker_range(9, 3, 2), (6, 9));
+    }
+
+    #[test]
+    fn contiguous_worker_range_spreads_remainder_to_early_workers() {
+        // 10 chunks across 3 workers: the extra chunk goes to worker 0.
+        assert_eq!(contiguous_worker_range(10, 3, 0), (0, 4));
+        assert_eq!(contiguous_worker_range(10, 3, 1), (4, 7));
+        assert_eq!(contiguous_worker_range(10, 3, 2), (7, 10));
+    }
+
+    #[test]
+    fn contiguous_worker_ranges_cover_all_chunks_without_gaps() {
+        let chunk_count = 37;
+        let worker_count = 8;
+        let mut covered = Vec::new();
+        for worker in 0..worker_count {
+            let (start, end) = contiguous_worker_range(chunk_count, worker_count, worker);
+            assert!(start <= end);
+            covered.extend(start..end);
+        }
+        let expected: Vec<usize> = (0..chunk_count).collect();
+        assert_eq!(covered, expected);
+    }
+
+    #[test]
+    fn contiguous_worker_range_handles_more_workers_than_chunks() {
+        // 2 chunks, 4 workers: workers 2 and 3 get empty ranges.
+        assert_eq!(contiguous_worker_range(2, 4, 0), (0, 1));
+        assert_eq!(contiguous_worker_range(2, 4, 1), (1, 2));
+        assert_eq!(contiguous_worker_range(2, 4, 2), (2, 2));
+        assert_eq!(contiguous_worker_range(2, 4, 3), (2, 2));
+    }
+
+    #[test]
+    fn worker_panicked_extracts_str_and_string_payloads() {
+        let from_str = worker_panicked(Box::new("boom"));
+        assert!(from_str.to_string().contains("boom"));
+
+        let from_string = worker_panicked(Box::new(String::from("kaboom")));
+        assert!(from_string.to_string().contains("kaboom"));
+
+        let from_unknown = worker_panicked(Box::new(42u32));
+        assert!(from_unknown.to_string().contains("unknown panic payload"));
+    }
+
+    #[test]
+    fn channel_closed_and_parallelism_errors_are_io() {
+        assert!(channel_closed().is_io_error());
+        let err = available_parallelism_error(io::Error::other("nope"));
+        assert!(err.is_io_error());
+        assert!(err.to_string().contains("available parallelism"));
+    }
+}

--- a/src/raw_mft/reader.rs
+++ b/src/raw_mft/reader.rs
@@ -47,6 +47,29 @@ pub(super) fn entry_build_options(options: &RawMftScanOptions) -> EntryBuildOpti
     }
 }
 
+/// Look up, borrow, validate, and USA-fix-up one base FILE record.
+///
+/// Returns `Ok(None)` when the record number maps to a sparse hole in the
+/// `$MFT` or the bytes are not a valid FILE record. Shared by the rich and
+/// lean per-record readers below.
+fn parse_record_at<'b>(
+    reader: &'b mut VolumeReader,
+    boot: &BootSector,
+    extent_map: &ExtentMap,
+    record_number: u64,
+) -> Result<Option<FileRecord<'b>>, UsnError> {
+    let Some(offset) = extent_map.record_offset(record_number)? else {
+        return Ok(None);
+    };
+    let buf = reader
+        .borrow_at(offset, boot.file_record_size as usize)
+        .map_err(io_err)?;
+    if !FileRecord::is_valid(buf) {
+        return Ok(None);
+    }
+    Ok(Some(FileRecord::parse(record_number, Some(offset), buf)?))
+}
+
 /// Read one raw FILE record and return the rich entry plus any captured
 /// `$ATTRIBUTE_LIST` payload.
 pub(super) fn read_record_raw(
@@ -56,17 +79,9 @@ pub(super) fn read_record_raw(
     record_number: u64,
     build_options: EntryBuildOptions,
 ) -> Result<Option<(RawMftEntry, Option<AttributeListInfo>)>, UsnError> {
-    let offset = match extent_map.record_offset(record_number)? {
-        Some(offset) => offset,
-        None => return Ok(None),
-    };
-    let buf = reader
-        .borrow_at(offset, boot.file_record_size as usize)
-        .map_err(io_err)?;
-    if !FileRecord::is_valid(buf) {
+    let Some(rec) = parse_record_at(reader, boot, extent_map, record_number)? else {
         return Ok(None);
-    }
-    let rec = FileRecord::parse(record_number, Some(offset), buf)?;
+    };
     Ok(Some(RawMftEntry::from_record_with_attr_list(
         &rec,
         build_options,
@@ -82,17 +97,9 @@ pub(super) fn read_batch_record_raw(
     record_number: u64,
     collect_dos_file_name_links: bool,
 ) -> Result<Option<(RawMftBatchScratch, Option<AttributeListInfo>)>, UsnError> {
-    let offset = match extent_map.record_offset(record_number)? {
-        Some(offset) => offset,
-        None => return Ok(None),
-    };
-    let buf = reader
-        .borrow_at(offset, boot.file_record_size as usize)
-        .map_err(io_err)?;
-    if !FileRecord::is_valid(buf) {
+    let Some(rec) = parse_record_at(reader, boot, extent_map, record_number)? else {
         return Ok(None);
-    }
-    let rec = FileRecord::parse(record_number, Some(offset), buf)?;
+    };
     Ok(Some(RawMftBatchScratch::from_record_with_attr_list(
         &rec,
         collect_dos_file_name_links,

--- a/src/raw_mft/tests.rs
+++ b/src/raw_mft/tests.rs
@@ -16,6 +16,53 @@ fn options_defaults_are_sensible() {
     assert!(o.range().end_record().is_none());
 }
 
+#[test]
+fn raw_mft_entry_display_is_compact() {
+    use crate::{Fid, FileAttributes, Filetime};
+
+    let entry = RawMftEntry {
+        record_number: 42,
+        sequence_number: 1,
+        file_reference: Fid::from_parts(42, 1),
+        parent_reference: Fid::from_parts(5, 1),
+        base_record_reference: 0,
+        hard_link_count: 2,
+        flags: 0,
+        is_used: true,
+        is_directory: false,
+        is_reparse_point: false,
+        reparse_tag: None,
+        namespace: FileNameNamespace::Win32,
+        file_name: std::ffi::OsString::from("file.txt"),
+        si_created: Filetime::new(0),
+        si_modified: Filetime::new(0),
+        si_mft_modified: Filetime::new(0),
+        si_accessed: Filetime::new(0),
+        si_file_attributes: FileAttributes::empty(),
+        fn_created: Filetime::new(0),
+        fn_modified: Filetime::new(0),
+        fn_mft_modified: Filetime::new(0),
+        fn_accessed: Filetime::new(0),
+        real_size: 1234,
+        allocated_size: 4096,
+        has_unnamed_data: true,
+        is_resident: false,
+        is_sparse: false,
+        is_compressed: false,
+        is_encrypted: false,
+        data_run_summary: None,
+        alternate_data_streams: Box::default(),
+        links: Box::default(),
+    };
+
+    let text = entry.to_string();
+    assert!(text.contains("raw #42"));
+    assert!(text.contains("FILE"));
+    assert!(text.contains("links=2"));
+    assert!(text.contains("size=1234"));
+    assert!(text.contains("\"file.txt\""));
+}
+
 mod integration_tests {
     use super::super::*;
     use crate::volume::Volume;

--- a/src/time.rs
+++ b/src/time.rs
@@ -20,6 +20,9 @@ pub(crate) const WINDOWS_TO_UNIX_OFFSET_100NS: u64 = 116_444_736_000_000_000u64;
 pub struct Filetime(u64);
 
 impl Filetime {
+    /// The Unix epoch (1970-01-01 UTC) expressed as a `Filetime`.
+    pub const UNIX_EPOCH: Self = Self(WINDOWS_TO_UNIX_OFFSET_100NS);
+
     /// Construct a `Filetime` from its raw 100-ns interval count.
     #[must_use]
     #[inline]
@@ -32,6 +35,14 @@ impl Filetime {
     #[inline]
     pub const fn raw(self) -> u64 {
         self.0
+    }
+
+    /// Returns `true` if this is the zero `Filetime` (the value NTFS and the USN
+    /// journal use for an unset timestamp).
+    #[must_use]
+    #[inline]
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
     }
 
     /// Convert to `SystemTime`.
@@ -71,12 +82,49 @@ impl Filetime {
         seconds.clamp(i64::MIN as i128, i64::MAX as i128) as i64
     }
 
+    /// Number of milliseconds since the Unix epoch (may be negative).
+    #[must_use]
+    #[inline]
+    pub fn to_unix_millis(self) -> i64 {
+        let intervals = self.0 as i128 - WINDOWS_TO_UNIX_OFFSET_100NS as i128;
+        let millis = intervals / 10_000;
+        millis.clamp(i64::MIN as i128, i64::MAX as i128) as i64
+    }
+
     /// Number of nanoseconds since the Unix epoch (may be negative).
     #[must_use]
     #[inline]
     pub fn to_unix_nanos(self) -> i128 {
         let intervals = self.0 as i128 - WINDOWS_TO_UNIX_OFFSET_100NS as i128;
         intervals * 100
+    }
+
+    /// Construct a `Filetime` from a whole number of seconds since the Unix epoch.
+    ///
+    /// Returns `None` when the result would fall before the Windows FILETIME
+    /// epoch (1601-01-01) or overflow the underlying `u64`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use usn_journal_rs::Filetime;
+    ///
+    /// let epoch = Filetime::from_unix_seconds(0).unwrap();
+    /// assert_eq!(epoch, Filetime::UNIX_EPOCH);
+    /// assert_eq!(epoch.to_unix_seconds(), 0);
+    ///
+    /// // Dates before 1601 are unrepresentable.
+    /// assert!(Filetime::from_unix_seconds(-20_000_000_000).is_none());
+    /// ```
+    #[must_use]
+    pub fn from_unix_seconds(seconds: i64) -> Option<Self> {
+        let intervals = (seconds as i128).checked_mul(10_000_000)?;
+        let raw = intervals.checked_add(WINDOWS_TO_UNIX_OFFSET_100NS as i128)?;
+        if (0..=u64::MAX as i128).contains(&raw) {
+            Some(Self(raw as u64))
+        } else {
+            None
+        }
     }
 }
 
@@ -286,6 +334,13 @@ mod tests {
         }
 
         #[test]
+        fn unix_nanos_is_negative_before_unix_epoch() {
+            // 1 second before the Unix epoch should be -1_000_000_000 ns.
+            let f = Filetime::new(WINDOWS_TO_UNIX_OFFSET_100NS - 10_000_000);
+            assert_eq!(f.to_unix_nanos(), -1_000_000_000);
+        }
+
+        #[test]
         fn zero_is_windows_epoch() {
             let f = Filetime::new(0);
             // Windows epoch: 1601-01-01. Should be representable as
@@ -329,6 +384,83 @@ mod tests {
                 filetime.raw(),
                 WINDOWS_TO_UNIX_OFFSET_100NS + 10_000_000 + 1_234_567
             );
+        }
+
+        #[test]
+        fn from_system_time_truncates_below_100ns_resolution() {
+            // FILETIME has 100 ns resolution; sub-tick nanoseconds are dropped.
+            let st = UNIX_EPOCH + Duration::new(0, 150);
+            let filetime = Filetime::from_system_time(st).expect("system time");
+            assert_eq!(filetime.raw(), WINDOWS_TO_UNIX_OFFSET_100NS + 1);
+        }
+
+        #[test]
+        fn unix_seconds_and_nanos_for_known_post_epoch_value() {
+            // 2020-01-01T00:00:00Z in FILETIME 100 ns ticks.
+            let filetime = Filetime::new(132_223_104_000_000_000);
+            assert_eq!(filetime.to_unix_seconds(), 1_577_836_800);
+            assert_eq!(
+                filetime.to_unix_nanos(),
+                1_577_836_800 * 1_000_000_000
+            );
+        }
+
+        #[test]
+        fn max_raw_round_trips_through_win32_filetime() {
+            let filetime = Filetime::new(u64::MAX);
+            let win32: FILETIME = filetime.into();
+            assert_eq!(Filetime::from(win32), filetime);
+            assert_eq!(win32.dwLowDateTime, u32::MAX);
+            assert_eq!(win32.dwHighDateTime, u32::MAX);
+        }
+
+        #[test]
+        fn system_time_round_trips_for_far_future_date() {
+            // ~ year 2200, comfortably inside both representations.
+            let raw = 189_000_000_000_000_000u64;
+            let filetime = Filetime::new(raw);
+            let system_time = filetime.to_system_time().expect("representable");
+            let back = Filetime::from_system_time(system_time).expect("round trip");
+            assert_eq!(back, filetime);
+        }
+
+        #[test]
+        fn unix_epoch_const_matches_offset() {
+            assert_eq!(Filetime::UNIX_EPOCH.raw(), WINDOWS_TO_UNIX_OFFSET_100NS);
+            assert_eq!(Filetime::UNIX_EPOCH.to_unix_seconds(), 0);
+            assert_eq!(Filetime::UNIX_EPOCH.to_system_time(), Some(UNIX_EPOCH));
+        }
+
+        #[test]
+        fn is_zero_detects_unset_timestamp() {
+            assert!(Filetime::new(0).is_zero());
+            assert!(!Filetime::UNIX_EPOCH.is_zero());
+        }
+
+        #[test]
+        fn to_unix_millis_for_known_value() {
+            // Unix epoch + 1.5 seconds = 1500 ms.
+            let filetime = Filetime::new(WINDOWS_TO_UNIX_OFFSET_100NS + 15_000_000);
+            assert_eq!(filetime.to_unix_millis(), 1500);
+            // One millisecond before the epoch.
+            let before = Filetime::new(WINDOWS_TO_UNIX_OFFSET_100NS - 10_000);
+            assert_eq!(before.to_unix_millis(), -1);
+        }
+
+        #[test]
+        fn from_unix_seconds_round_trips_and_bounds() {
+            let filetime = Filetime::from_unix_seconds(0).expect("epoch");
+            assert_eq!(filetime, Filetime::UNIX_EPOCH);
+
+            let y2020 = Filetime::from_unix_seconds(1_577_836_800).expect("2020");
+            assert_eq!(y2020.to_unix_seconds(), 1_577_836_800);
+
+            // A second before the Unix epoch is still valid (post-1601).
+            let pre_epoch = Filetime::from_unix_seconds(-1).expect("pre-epoch");
+            assert_eq!(pre_epoch.to_unix_seconds(), -1);
+
+            // Far in the past (pre-1601) is unrepresentable.
+            assert!(Filetime::from_unix_seconds(-20_000_000_000).is_none());
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,6 +14,10 @@ use std::fmt;
 pub struct Usn(pub i64);
 
 impl Usn {
+    /// The zero USN — the conventional starting cursor for a full journal or
+    /// MFT scan.
+    pub const ZERO: Self = Self(0);
+
     /// Construct a `Usn` from its raw signed integer representation.
     #[inline]
     pub const fn new(v: i64) -> Self {
@@ -24,6 +28,31 @@ impl Usn {
     #[inline]
     pub const fn get(self) -> i64 {
         self.0
+    }
+
+    /// Returns `true` if this is the zero USN (the conventional scan start).
+    #[must_use]
+    #[inline]
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Advance this USN by `delta`, saturating at the numeric bounds.
+    ///
+    /// USNs are byte offsets into the change journal, so advancing by a byte
+    /// delta is occasionally useful when resuming a scan.
+    #[inline]
+    pub const fn saturating_add(self, delta: i64) -> Self {
+        Self(self.0.saturating_add(delta))
+    }
+
+    /// Advance this USN by `delta`, returning `None` on overflow.
+    #[inline]
+    pub const fn checked_add(self, delta: i64) -> Option<Self> {
+        match self.0.checked_add(delta) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
     }
 }
 
@@ -80,12 +109,6 @@ impl Fid {
     /// Construct a standard 64-bit NTFS file reference number.
     #[inline]
     pub const fn new(v: u64) -> Self {
-        Self::from_u64(v)
-    }
-
-    /// Construct a standard 64-bit NTFS file reference number.
-    #[inline]
-    pub const fn from_u64(v: u64) -> Self {
         Self::Standard(v)
     }
 
@@ -99,6 +122,28 @@ impl Fid {
     #[inline]
     pub const fn from_bytes(bytes: [u8; 16]) -> Self {
         Self::Extended(u128::from_le_bytes(bytes))
+    }
+
+    /// Construct a standard NTFS file reference from its 48-bit record number
+    /// and 16-bit sequence number — the inverse of [`Self::record_number`] and
+    /// [`Self::sequence`].
+    ///
+    /// The record number is masked to its low 48 bits.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use usn_journal_rs::Fid;
+    ///
+    /// let fid = Fid::from_parts(0x2a, 0xabcd);
+    /// assert_eq!(fid.record_number(), Some(0x2a));
+    /// assert_eq!(fid.sequence(), Some(0xabcd));
+    /// ```
+    #[inline]
+    pub const fn from_parts(record_number: u64, sequence: u16) -> Self {
+        Self::Standard(
+            ((sequence as u64) << Self::SEQUENCE_SHIFT) | (record_number & Self::RECORD_NUMBER_MASK),
+        )
     }
 
     /// Returns `true` if this is a standard NTFS 64-bit file reference.
@@ -195,6 +240,28 @@ impl fmt::Display for Fid {
     }
 }
 
+impl fmt::LowerHex for Fid {
+    /// Bare lowercase hex of the underlying identifier. Honors the `#` flag for
+    /// the `0x` prefix, so `format!("{:#x}", fid)` matches the `Display` form.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Standard(v) => fmt::LowerHex::fmt(v, f),
+            Self::Extended(v) => fmt::LowerHex::fmt(v, f),
+        }
+    }
+}
+
+impl fmt::UpperHex for Fid {
+    /// Bare uppercase hex of the underlying identifier. Honors the `#` flag for
+    /// the `0X` prefix.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Standard(v) => fmt::UpperHex::fmt(v, f),
+            Self::Extended(v) => fmt::UpperHex::fmt(v, f),
+        }
+    }
+}
+
 bitflags::bitflags! {
     /// Strongly-typed view over an NTFS file-attribute bitmask
     /// (the value stored in `USN_RECORD_V2::FileAttributes`,
@@ -244,6 +311,85 @@ bitflags::bitflags! {
         const RECALL_ON_OPEN       = 0x0004_0000;
         /// Item is recalled on data access.
         const RECALL_ON_DATA_ACCESS = 0x0040_0000;
+    }
+}
+
+impl FileAttributes {
+    /// Returns `true` if the directory attribute is set.
+    #[must_use]
+    #[inline]
+    pub fn is_directory(self) -> bool {
+        self.contains(Self::DIRECTORY)
+    }
+
+    /// Returns `true` if the read-only attribute is set.
+    #[must_use]
+    #[inline]
+    pub fn is_read_only(self) -> bool {
+        self.contains(Self::READ_ONLY)
+    }
+
+    /// Returns `true` if the hidden attribute is set.
+    #[must_use]
+    #[inline]
+    pub fn is_hidden(self) -> bool {
+        self.contains(Self::HIDDEN)
+    }
+
+    /// Returns `true` if the system attribute is set.
+    #[must_use]
+    #[inline]
+    pub fn is_system(self) -> bool {
+        self.contains(Self::SYSTEM)
+    }
+
+    /// Returns `true` if the archive attribute is set.
+    #[must_use]
+    #[inline]
+    pub fn is_archive(self) -> bool {
+        self.contains(Self::ARCHIVE)
+    }
+
+    /// Returns `true` if the item is a reparse point (symlink, mount point, etc.).
+    #[must_use]
+    #[inline]
+    pub fn is_reparse_point(self) -> bool {
+        self.contains(Self::REPARSE_POINT)
+    }
+
+    /// Returns `true` if the item is stored compressed on disk.
+    #[must_use]
+    #[inline]
+    pub fn is_compressed(self) -> bool {
+        self.contains(Self::COMPRESSED)
+    }
+
+    /// Returns `true` if the item is stored encrypted on disk.
+    #[must_use]
+    #[inline]
+    pub fn is_encrypted(self) -> bool {
+        self.contains(Self::ENCRYPTED)
+    }
+
+    /// Returns `true` if the item contains sparse data.
+    #[must_use]
+    #[inline]
+    pub fn is_sparse(self) -> bool {
+        self.contains(Self::SPARSE_FILE)
+    }
+
+    /// Returns `true` if the item's data is not immediately available (offline).
+    #[must_use]
+    #[inline]
+    pub fn is_offline(self) -> bool {
+        self.contains(Self::OFFLINE)
+    }
+
+    /// Returns `true` if the item is marked temporary.
+    #[must_use]
+    #[inline]
+    pub fn is_temporary(self) -> bool {
+        self.contains(Self::TEMPORARY)
     }
 }
 
@@ -307,6 +453,55 @@ bitflags::bitflags! {
     }
 }
 
+impl UsnReason {
+    /// Every reason bit set — including bits this crate does not yet name.
+    ///
+    /// This is the recommended catch-all value for
+    /// [`JournalIterOptions`](crate::journal::JournalIterOptions)'s reason mask:
+    /// unlike [`UsnReason::all`] (which only covers the flags defined above), it
+    /// also matches reason bits introduced by newer Windows versions so no
+    /// records are filtered out.
+    pub const ALL: Self = Self::from_bits_retain(0xFFFF_FFFF);
+
+    /// Returns `true` if this change created a file or directory.
+    #[must_use]
+    #[inline]
+    pub fn is_file_create(self) -> bool {
+        self.contains(Self::FILE_CREATE)
+    }
+
+    /// Returns `true` if this change deleted a file or directory.
+    #[must_use]
+    #[inline]
+    pub fn is_file_delete(self) -> bool {
+        self.contains(Self::FILE_DELETE)
+    }
+
+    /// Returns `true` if this record is part of a rename (either the old or the
+    /// new name half of the operation).
+    #[must_use]
+    #[inline]
+    pub fn is_rename(self) -> bool {
+        self.intersects(Self::RENAME_OLD_NAME | Self::RENAME_NEW_NAME)
+    }
+
+    /// Returns `true` if the handle that caused the change was closed
+    /// (the [`CLOSE`](Self::CLOSE) bit — the final record for a change set).
+    #[must_use]
+    #[inline]
+    pub fn is_close(self) -> bool {
+        self.contains(Self::CLOSE)
+    }
+
+    /// Returns `true` if any unnamed-stream data change occurred
+    /// (overwrite, extend, or truncation).
+    #[must_use]
+    #[inline]
+    pub fn is_data_change(self) -> bool {
+        self.intersects(Self::DATA_OVERWRITE | Self::DATA_EXTEND | Self::DATA_TRUNCATION)
+    }
+}
+
 bitflags::bitflags! {
     /// Strongly-typed view over a USN source-info bitmask.
     ///
@@ -327,38 +522,22 @@ bitflags::bitflags! {
 }
 
 /// Display names for known `USN_SOURCE_*` bits.
-const SOURCE_INFO_NAMES: &[(UsnSourceInfo, &str)] = &[
-    (UsnSourceInfo::DATA_MANAGEMENT, "DATA_MANAGEMENT"),
-    (UsnSourceInfo::AUXILIARY_DATA, "AUXILIARY_DATA"),
+const SOURCE_INFO_NAMES: &[(u32, &str)] = &[
+    (UsnSourceInfo::DATA_MANAGEMENT.bits(), "DATA_MANAGEMENT"),
+    (UsnSourceInfo::AUXILIARY_DATA.bits(), "AUXILIARY_DATA"),
     (
-        UsnSourceInfo::REPLICATION_MANAGEMENT,
+        UsnSourceInfo::REPLICATION_MANAGEMENT.bits(),
         "REPLICATION_MANAGEMENT",
     ),
     (
-        UsnSourceInfo::CLIENT_REPLICATION_MANAGEMENT,
+        UsnSourceInfo::CLIENT_REPLICATION_MANAGEMENT.bits(),
         "CLIENT_REPLICATION_MANAGEMENT",
     ),
 ];
 
 impl fmt::Display for UsnSourceInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut wrote = false;
-        for (flag, name) in SOURCE_INFO_NAMES {
-            if self.contains(*flag) {
-                if wrote {
-                    f.write_str(" | ")?;
-                }
-                f.write_str(name)?;
-                wrote = true;
-            }
-        }
-        if wrote {
-            Ok(())
-        } else if self.is_empty() {
-            f.write_str("NONE")
-        } else {
-            write!(f, "0x{:x}", self.bits())
-        }
+        crate::display::write_flag_names(f, self.bits(), SOURCE_INFO_NAMES, " | ")
     }
 }
 
@@ -378,6 +557,33 @@ mod tests {
     #[test]
     fn usn_display_is_decimal() {
         assert_eq!(format!("{}", Usn::new(0x10)), "16");
+    }
+
+    #[test]
+    fn usn_is_zero_and_arithmetic() {
+        assert!(Usn::ZERO.is_zero());
+        assert!(!Usn::new(1).is_zero());
+
+        assert_eq!(Usn::new(10).saturating_add(5), Usn::new(15));
+        assert_eq!(Usn::new(i64::MAX).saturating_add(1), Usn::new(i64::MAX));
+
+        assert_eq!(Usn::new(10).checked_add(5), Some(Usn::new(15)));
+        assert_eq!(Usn::new(i64::MAX).checked_add(1), None);
+    }
+
+    #[test]
+    fn fid_hex_formatting_composes_with_specifiers() {
+        let fid = Fid::new(0xDEAD);
+        // Display keeps the 0x prefix.
+        assert_eq!(format!("{fid}"), "0xdead");
+        // Bare LowerHex / UpperHex, with the `#` flag adding the prefix.
+        assert_eq!(format!("{fid:x}"), "dead");
+        assert_eq!(format!("{fid:X}"), "DEAD");
+        assert_eq!(format!("{fid:#x}"), "0xdead");
+        assert_eq!(format!("{fid:#X}"), "0xDEAD");
+
+        let ext = Fid::from_u128(0x1234_5678_9abc_def0);
+        assert_eq!(format!("{ext:x}"), "123456789abcdef0");
     }
 
     #[test]
@@ -412,6 +618,20 @@ mod tests {
     }
 
     #[test]
+    fn fid_from_parts_round_trips_record_and_sequence() {
+        let fid = Fid::from_parts(0x2A, 0xABCD);
+        assert!(fid.is_standard());
+        assert_eq!(fid.record_number(), Some(0x2A));
+        assert_eq!(fid.sequence(), Some(0xABCD));
+        assert_eq!(fid.as_u64(), Some((0xABCDu64 << 48) | 0x2A));
+
+        // Record numbers are masked to the low 48 bits.
+        let masked = Fid::from_parts(u64::MAX, 0);
+        assert_eq!(masked.record_number(), Some((1u64 << 48) - 1));
+        assert_eq!(masked.sequence(), Some(0));
+    }
+
+    #[test]
     fn fid_display_is_hex() {
         assert_eq!(format!("{}", Fid::new(0x10)), "0x10");
     }
@@ -422,7 +642,6 @@ mod tests {
         let u: u64 = v.try_into().expect("standard fid");
         assert_eq!(u, 0xDEAD_BEEF);
         assert_eq!(Fid::from(0x42u64).as_u64(), Some(0x42));
-        assert_eq!(Fid::from_u64(0x42).as_u64(), Some(0x42));
     }
 
     #[test]
@@ -449,5 +668,87 @@ mod tests {
         ];
         let fid = Fid::from_bytes(raw);
         assert_eq!(fid.as_bytes(), raw);
+    }
+
+    #[test]
+    fn standard_fid_from_u128_and_as_u128_zero_extends() {
+        let fid = Fid::new(0x42);
+        assert_eq!(fid.as_u128(), 0x42);
+        assert_eq!(fid.as_bytes()[0], 0x42);
+        assert!(fid.as_bytes()[8..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn fid_from_u128_is_extended() {
+        let fid = Fid::from(0x1_0000_0000_0000_0001u128);
+        assert!(fid.is_extended());
+        assert_eq!(fid.as_u128(), 0x1_0000_0000_0000_0001u128);
+        assert_eq!(fid.as_u64(), None);
+    }
+
+    #[test]
+    fn usn_reason_all_is_full_mask() {
+        assert_eq!(UsnReason::ALL.bits(), 0xFFFF_FFFF);
+    }
+
+    #[test]
+    fn usn_reason_all_contains_every_named_flag() {
+        // ALL must be a superset of bitflags' `all()` (the named flags) and then
+        // some (the reserved/unknown bits), so newer reason bits still match.
+        assert!(UsnReason::ALL.contains(UsnReason::all()));
+        assert!(UsnReason::ALL.contains(UsnReason::FILE_CREATE | UsnReason::CLOSE));
+    }
+
+    #[test]
+    fn usn_zero_const_is_zero() {
+        assert_eq!(Usn::ZERO, Usn::new(0));
+        assert_eq!(Usn::ZERO.get(), 0);
+    }
+
+    #[test]
+    fn usn_reason_predicates() {
+        assert!(UsnReason::FILE_CREATE.is_file_create());
+        assert!(!UsnReason::FILE_DELETE.is_file_create());
+        assert!(UsnReason::FILE_DELETE.is_file_delete());
+        assert!(UsnReason::RENAME_OLD_NAME.is_rename());
+        assert!(UsnReason::RENAME_NEW_NAME.is_rename());
+        assert!(!UsnReason::FILE_CREATE.is_rename());
+        assert!(UsnReason::CLOSE.is_close());
+        assert!(UsnReason::DATA_EXTEND.is_data_change());
+        assert!(UsnReason::DATA_TRUNCATION.is_data_change());
+        assert!(!UsnReason::BASIC_INFO_CHANGE.is_data_change());
+    }
+
+    #[test]
+    fn file_attributes_predicates() {
+        assert!(FileAttributes::DIRECTORY.is_directory());
+        assert!(FileAttributes::HIDDEN.is_hidden());
+        assert!(FileAttributes::READ_ONLY.is_read_only());
+        assert!(FileAttributes::SYSTEM.is_system());
+        assert!(FileAttributes::ARCHIVE.is_archive());
+        assert!(FileAttributes::REPARSE_POINT.is_reparse_point());
+        assert!(FileAttributes::COMPRESSED.is_compressed());
+        assert!(FileAttributes::ENCRYPTED.is_encrypted());
+        assert!(FileAttributes::SPARSE_FILE.is_sparse());
+        assert!(FileAttributes::OFFLINE.is_offline());
+        assert!(FileAttributes::TEMPORARY.is_temporary());
+        assert!(!FileAttributes::ARCHIVE.is_directory());
+
+        let combined = FileAttributes::DIRECTORY | FileAttributes::HIDDEN;
+        assert!(combined.is_directory());
+        assert!(combined.is_hidden());
+        assert!(!combined.is_read_only());
+    }
+
+    #[test]
+    fn usn_source_info_display_lists_known_flags() {
+        let info = UsnSourceInfo::DATA_MANAGEMENT | UsnSourceInfo::REPLICATION_MANAGEMENT;
+        assert_eq!(info.to_string(), "DATA_MANAGEMENT | REPLICATION_MANAGEMENT");
+    }
+
+    #[test]
+    fn file_attributes_display_lists_known_flags() {
+        let attrs = FileAttributes::DIRECTORY | FileAttributes::HIDDEN;
+        assert_eq!(attrs.to_string(), "HIDDEN | DIRECTORY");
     }
 }

--- a/src/usn_record.rs
+++ b/src/usn_record.rs
@@ -407,4 +407,218 @@ mod tests {
             }
         ));
     }
+
+    /// Build a `USN_RECORD_V2` buffer with the given fields and file name.
+    fn build_v2_record(
+        usn: i64,
+        fid: u64,
+        parent: u64,
+        reason: u32,
+        attributes: u32,
+        name: &str,
+    ) -> Vec<u8> {
+        let name_u16: Vec<u16> = name.encode_utf16().collect();
+        let name_len = name_u16.len() * size_of::<u16>();
+        let base = size_of::<USN_RECORD_V2>();
+        let total = (base + name_len).next_multiple_of(8);
+        let name_offset = std::mem::offset_of!(USN_RECORD_V2, FileName);
+
+        let record = USN_RECORD_V2 {
+            RecordLength: total as u32,
+            MajorVersion: 2,
+            MinorVersion: 0,
+            FileReferenceNumber: fid,
+            ParentFileReferenceNumber: parent,
+            Usn: usn,
+            TimeStamp: 0,
+            Reason: reason,
+            SourceInfo: 0,
+            SecurityId: 0,
+            FileAttributes: attributes,
+            FileNameLength: name_len as u16,
+            FileNameOffset: name_offset as u16,
+            FileName: [0; 1],
+        };
+
+        let mut buf = vec![0u8; total];
+        // SAFETY: copy the header bytes up to (not including) the FileName
+        // placeholder, then splice the real UTF-16 name in at FileNameOffset.
+        unsafe {
+            ptr::copy_nonoverlapping(
+                &record as *const USN_RECORD_V2 as *const u8,
+                buf.as_mut_ptr(),
+                name_offset,
+            );
+            ptr::copy_nonoverlapping(
+                name_u16.as_ptr() as *const u8,
+                buf.as_mut_ptr().add(name_offset),
+                name_len,
+            );
+        }
+        buf
+    }
+
+    /// Build a `USN_RECORD_V3` buffer carrying 128-bit file IDs.
+    fn build_v3_record(usn: i64, fid: u128, parent: u128, name: &str) -> Vec<u8> {
+        use windows::Win32::Storage::FileSystem::FILE_ID_128;
+
+        let name_u16: Vec<u16> = name.encode_utf16().collect();
+        let name_len = name_u16.len() * size_of::<u16>();
+        let base = size_of::<USN_RECORD_V3>();
+        let total = (base + name_len).next_multiple_of(8);
+        let name_offset = std::mem::offset_of!(USN_RECORD_V3, FileName);
+
+        let record = USN_RECORD_V3 {
+            RecordLength: total as u32,
+            MajorVersion: 3,
+            MinorVersion: 0,
+            FileReferenceNumber: FILE_ID_128 {
+                Identifier: fid.to_le_bytes(),
+            },
+            ParentFileReferenceNumber: FILE_ID_128 {
+                Identifier: parent.to_le_bytes(),
+            },
+            Usn: usn,
+            TimeStamp: 0,
+            Reason: 0,
+            SourceInfo: 0,
+            SecurityId: 0,
+            FileAttributes: 0,
+            FileNameLength: name_len as u16,
+            FileNameOffset: name_offset as u16,
+            FileName: [0; 1],
+        };
+
+        let mut buf = vec![0u8; total];
+        // SAFETY: same header-then-name splice as the V2 builder.
+        unsafe {
+            ptr::copy_nonoverlapping(
+                &record as *const USN_RECORD_V3 as *const u8,
+                buf.as_mut_ptr(),
+                name_offset,
+            );
+            ptr::copy_nonoverlapping(
+                name_u16.as_ptr() as *const u8,
+                buf.as_mut_ptr().add(name_offset),
+                name_len,
+            );
+        }
+        buf
+    }
+
+    #[test]
+    fn find_next_record_parses_v2_and_advances_offset() {
+        let buf = build_v2_record(0x1234, 0x42, 0x7, 0x0000_0100, 0x20, "file.txt");
+        let mut offset = 0u32;
+        let record = find_next_record(&buf, buf.len() as u32, &mut offset)
+            .expect("parse ok")
+            .expect("record present");
+
+        assert_eq!(record.usn(), 0x1234);
+        assert_eq!(record.fid(), Fid::new(0x42));
+        assert_eq!(record.parent_fid(), Fid::new(0x7));
+        assert_eq!(record.reason(), 0x0000_0100);
+        assert_eq!(record.file_attributes(), 0x20);
+        let name: Vec<u16> = "file.txt".encode_utf16().collect();
+        assert_eq!(record.file_name_slice(), name.as_slice());
+        assert_eq!(offset as usize, buf.len());
+    }
+
+    #[test]
+    fn find_next_record_iterates_multiple_v2_records() {
+        let mut buf = build_v2_record(1, 0x10, 0x5, 0, 0, "a.txt");
+        buf.extend(build_v2_record(2, 0x11, 0x5, 0, 0, "bb.txt"));
+        let total = buf.len() as u32;
+
+        let mut offset = 0u32;
+        let first = find_next_record(&buf, total, &mut offset)
+            .unwrap()
+            .expect("first record");
+        assert_eq!(first.usn(), 1);
+        assert_eq!(first.fid(), Fid::new(0x10));
+
+        let second = find_next_record(&buf, total, &mut offset)
+            .unwrap()
+            .expect("second record");
+        assert_eq!(second.usn(), 2);
+        assert_eq!(second.fid(), Fid::new(0x11));
+
+        assert_eq!(offset, total);
+        assert!(find_next_record(&buf, total, &mut offset).unwrap().is_none());
+    }
+
+    #[test]
+    fn find_next_record_parses_v3_extended_ids() {
+        let fid = 0x0011_2233_4455_6677_8899_aabb_ccdd_eeffu128;
+        let parent = 0x1000_0000_0000_0000_0000_0000_0000_0001u128;
+        let buf = build_v3_record(0x99, fid, parent, "refs.dat");
+
+        let mut offset = 0u32;
+        let record = find_next_record(&buf, buf.len() as u32, &mut offset)
+            .unwrap()
+            .expect("record present");
+
+        assert_eq!(record.usn(), 0x99);
+        assert_eq!(record.fid(), Fid::from(fid));
+        assert_eq!(record.parent_fid(), Fid::from(parent));
+        assert!(record.fid().is_extended());
+    }
+
+    #[test]
+    fn find_next_record_rejects_misaligned_file_name_length() {
+        let mut buf = build_v2_record(1, 0x10, 0x5, 0, 0, "abc");
+        // FileNameLength lives right before FileNameOffset in the header.
+        let len_off = std::mem::offset_of!(USN_RECORD_V2, FileNameLength);
+        buf[len_off..len_off + 2].copy_from_slice(&3u16.to_le_bytes());
+
+        let mut offset = 0u32;
+        let err = find_next_record(&buf, buf.len() as u32, &mut offset).unwrap_err();
+        assert!(matches!(err, UsnError::MisalignedRecord { offset: 0, .. }));
+    }
+
+    #[test]
+    fn find_next_record_rejects_file_name_beyond_record() {
+        let mut buf = build_v2_record(1, 0x10, 0x5, 0, 0, "abc");
+        // Declare a file-name length that runs past the record end.
+        let len_off = std::mem::offset_of!(USN_RECORD_V2, FileNameLength);
+        buf[len_off..len_off + 2].copy_from_slice(&1000u16.to_le_bytes());
+
+        let mut offset = 0u32;
+        let err = find_next_record(&buf, buf.len() as u32, &mut offset).unwrap_err();
+        assert!(matches!(
+            err,
+            UsnError::InvalidRecord {
+                offset: 0,
+                reason: "file name range exceeds record length"
+            }
+        ));
+    }
+
+    #[test]
+    fn find_next_record_returns_none_when_offset_at_end() {
+        let buf = build_v2_record(1, 0x10, 0x5, 0, 0, "a.txt");
+        let mut offset = buf.len() as u32;
+        assert!(
+            find_next_record(&buf, buf.len() as u32, &mut offset)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn read_cursor_helpers_read_leading_values() {
+        let mut usn_buf = vec![0u8; 16];
+        usn_buf[..8].copy_from_slice(&0x0123_4567i64.to_le_bytes());
+        assert_eq!(
+            read_next_start_usn(&usn_buf, usn_buf.len() as u32).unwrap(),
+            Usn::new(0x0123_4567)
+        );
+
+        let mut fid_buf = vec![0u8; 16];
+        fid_buf[..8].copy_from_slice(&0xDEAD_BEEFu64.to_le_bytes());
+        assert_eq!(
+            read_next_start_fid(&fid_buf, fid_buf.len() as u32).unwrap(),
+            0xDEAD_BEEF
+        );
+    }
 }

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -39,6 +39,19 @@ pub struct Volume {
 impl Volume {
     /// Creates a new `Volume` instance with the given drive letter.
     ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use usn_journal_rs::volume::Volume;
+    ///
+    /// // Requires Administrator privileges.
+    /// let volume = Volume::from_drive_letter('C')?;
+    /// for result in volume.journal().try_iter()?.take(10) {
+    ///     println!("{}", result?);
+    /// }
+    /// # Ok::<(), usn_journal_rs::UsnError>(())
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns [`UsnError::NotElevated`] if the process does not have the
@@ -58,7 +71,7 @@ impl Volume {
     ///
     /// Returns [`UsnError::NotElevated`] if the process does not have the
     /// Administrator privileges required to open raw volume handles. Returns
-    /// [`UsnError::WinApi`] or [`UsnError::InvalidMountPointError`] if the
+    /// [`UsnError::WinApi`] or [`UsnError::InvalidMountPoint`] if the
     /// mount point cannot be resolved to a volume handle.
     pub fn from_mount_point<P: AsRef<Path>>(mount_point: P) -> Result<Self, UsnError> {
         let path = mount_point.as_ref();
@@ -175,7 +188,7 @@ fn get_volume_handle_from_mount_point(mount_point: &Path) -> Result<HANDLE, UsnE
         .unwrap_or(volume_name.len());
     let name_data = volume_name
         .get(..end)
-        .ok_or_else(|| UsnError::InvalidMountPointError("Failed to get volume name data".into()))?;
+        .ok_or_else(|| UsnError::InvalidMountPoint("Failed to get volume name data".into()))?;
     let volume_guid = String::from_utf16_lossy(name_data);
 
     debug!("Volume GUID: {volume_guid}");
@@ -205,9 +218,24 @@ fn get_volume_handle_from_mount_point(mount_point: &Path) -> Result<HANDLE, UsnE
 
 #[cfg(test)]
 mod tests {
-    use windows::Win32::Foundation::ERROR_FILE_NOT_FOUND;
+    use windows::Win32::Foundation::{ERROR_FILE_NOT_FOUND, HANDLE};
 
-    use crate::{errors::UsnError, volume::Volume};
+    use crate::{
+        errors::UsnError,
+        volume::{Volume, VolumeSource},
+    };
+
+    #[test]
+    fn volume_accessors_construct_without_io() {
+        // A mock volume has an invalid handle, but `journal()`, `mft()`, and
+        // `path_resolver()` only borrow the volume and perform no I/O at
+        // construction, so they must succeed.
+        let volume = Volume::mock(HANDLE(std::ptr::null_mut()), VolumeSource::DriveLetter('C'));
+        let _journal = volume.journal();
+        let _mft = volume.mft();
+        let _resolver = volume.path_resolver();
+        assert_eq!(volume.drive_letter(), Some('C'));
+    }
 
     // Integration tests that require actual filesystem access
     mod integration_tests {

--- a/tests/journal_query.rs
+++ b/tests/journal_query.rs
@@ -1,0 +1,105 @@
+//! Integration tests for the split `UsnJournal::query` / `query_or_create` API.
+//!
+//! These exercise the real USN journal on the `USN_TEST_DRIVE` volume
+//! (default `C`). They skip gracefully when the process is not elevated or
+//! the drive is unavailable.
+
+use usn_journal_rs::{errors::UsnError, volume::Volume};
+
+/// Pick the NTFS test volume, honoring `USN_TEST_DRIVE` (default `C`).
+fn pick_drive() -> char {
+    std::env::var("USN_TEST_DRIVE")
+        .ok()
+        .and_then(|s| s.chars().next())
+        .map(|c| c.to_ascii_uppercase())
+        .unwrap_or('C')
+}
+
+/// Open the test volume, or return `None` with a skip message.
+fn open_test_volume(test_name: &str) -> Option<Volume> {
+    let drive = pick_drive();
+    match Volume::from_drive_letter(drive) {
+        Ok(volume) => Some(volume),
+        Err(UsnError::NotElevated) => {
+            eprintln!("{test_name}: skipping (requires admin privileges)");
+            None
+        }
+        Err(error) => {
+            eprintln!("{test_name}: skipping on {drive}: {error}");
+            None
+        }
+    }
+}
+
+#[test]
+fn query_or_create_returns_self_consistent_state() {
+    let Some(volume) = open_test_volume("query_or_create_returns_self_consistent_state") else {
+        return;
+    };
+    let journal = volume.journal();
+
+    let data = journal
+        .query_or_create()
+        .expect("query_or_create should succeed on an NTFS volume");
+
+    assert_ne!(data.journal_id, 0, "an active journal must have a non-zero id");
+    assert!(
+        data.first_usn <= data.next_usn,
+        "first_usn ({}) must not exceed next_usn ({})",
+        data.first_usn,
+        data.next_usn
+    );
+    assert!(
+        data.lowest_valid_usn <= data.next_usn,
+        "lowest_valid_usn ({}) must not exceed next_usn ({})",
+        data.lowest_valid_usn,
+        data.next_usn
+    );
+    assert!(
+        data.maximum_size > 0,
+        "an active journal should report a non-zero maximum size"
+    );
+}
+
+#[test]
+fn query_succeeds_after_query_or_create() {
+    let Some(volume) = open_test_volume("query_succeeds_after_query_or_create") else {
+        return;
+    };
+    let journal = volume.journal();
+
+    // Ensure the journal exists first.
+    let created = journal
+        .query_or_create()
+        .expect("query_or_create should succeed on an NTFS volume");
+
+    // A plain query must now succeed (no JournalNotActive) and agree on the id.
+    let queried = journal
+        .query()
+        .expect("query should succeed once the journal is active");
+
+    assert_eq!(
+        created.journal_id, queried.journal_id,
+        "query and query_or_create must report the same journal id"
+    );
+}
+
+#[test]
+fn query_or_create_is_idempotent() {
+    let Some(volume) = open_test_volume("query_or_create_is_idempotent") else {
+        return;
+    };
+    let journal = volume.journal();
+
+    let first = journal
+        .query_or_create()
+        .expect("first query_or_create should succeed");
+    let second = journal
+        .query_or_create()
+        .expect("second query_or_create should succeed");
+
+    assert_eq!(
+        first.journal_id, second.journal_id,
+        "repeated query_or_create calls must not rotate the journal id"
+    );
+}

--- a/tests/path_resolver_consistency.rs
+++ b/tests/path_resolver_consistency.rs
@@ -73,9 +73,9 @@ fn all_three_resolvers_agree() {
     }
 
     // Build the three resolvers.
-    let mut resolver1 = PathResolver::new(&volume).with_directory_cache(0);
+    let resolver1 = PathResolver::new(&volume).with_directory_cache(0);
 
-    let mut resolver2 = PathResolver::new(&volume).with_directory_cache(1024);
+    let resolver2 = PathResolver::new(&volume).with_directory_cache(1024);
 
     let resolver3 = match raw_mft.path_resolver() {
         Ok(r) => r,

--- a/tests/raw_mft_mft_consistency.rs
+++ b/tests/raw_mft_mft_consistency.rs
@@ -64,7 +64,7 @@ fn raw_mft_and_mft_api_agree_on_sampled_entries() {
     const MIN_COMPARED: usize = 200;
     const PATH_TARGET: usize = 2_000;
 
-    let mut mft_path_resolver = PathResolver::new(&volume);
+    let mft_path_resolver = PathResolver::new(&volume);
     let mut mft_paths = HashSet::with_capacity(PATH_TARGET);
 
     let mut samples = Vec::with_capacity(SAMPLE_LIMIT);

--- a/tests/volume_accessors.rs
+++ b/tests/volume_accessors.rs
@@ -1,0 +1,214 @@
+//! Integration tests for the `Volume` convenience accessors
+//! (`journal()`, `mft()`, `raw_mft()`, `path_resolver()`) and a couple of
+//! MFT enumeration edge cases.
+//!
+//! Each accessor must be equivalent to the explicit constructor it wraps.
+//! Tests run against the `USN_TEST_DRIVE` volume (default `C`) and skip
+//! gracefully when the process is not elevated or the drive is unavailable.
+
+use usn_journal_rs::{
+    errors::UsnError,
+    journal::UsnJournal,
+    mft::{Mft, MftIterOptions},
+    path::PathResolver,
+    raw_mft::RawMft,
+    volume::Volume,
+    Usn,
+};
+
+/// Pick the NTFS test volume, honoring `USN_TEST_DRIVE` (default `C`).
+fn pick_drive() -> char {
+    std::env::var("USN_TEST_DRIVE")
+        .ok()
+        .and_then(|s| s.chars().next())
+        .map(|c| c.to_ascii_uppercase())
+        .unwrap_or('C')
+}
+
+/// Open the test volume, or return `None` with a skip message.
+fn open_test_volume(test_name: &str) -> Option<Volume> {
+    let drive = pick_drive();
+    match Volume::from_drive_letter(drive) {
+        Ok(volume) => Some(volume),
+        Err(UsnError::NotElevated) => {
+            eprintln!("{test_name}: skipping (requires admin privileges)");
+            None
+        }
+        Err(error) => {
+            eprintln!("{test_name}: skipping on {drive}: {error}");
+            None
+        }
+    }
+}
+
+#[test]
+fn journal_accessor_matches_constructor() {
+    let Some(volume) = open_test_volume("journal_accessor_matches_constructor") else {
+        return;
+    };
+
+    let via_accessor = volume
+        .journal()
+        .query_or_create()
+        .expect("accessor journal query_or_create should succeed");
+    let via_constructor = UsnJournal::new(&volume)
+        .query_or_create()
+        .expect("constructor journal query_or_create should succeed");
+
+    assert_eq!(
+        via_accessor.journal_id, via_constructor.journal_id,
+        "volume.journal() must wrap the same journal as UsnJournal::new"
+    );
+}
+
+#[test]
+fn mft_accessor_matches_constructor_first_entries() {
+    let Some(volume) = open_test_volume("mft_accessor_matches_constructor_first_entries") else {
+        return;
+    };
+
+    // The first enumerated MFT records are NTFS metafiles ($MFT, $MFTMirr,
+    // $LogFile, ...) whose file references are stable, so a bounded prefix
+    // read back-to-back must be identical between the two entry points.
+    const PREFIX: usize = 32;
+
+    let collect_prefix = |iter: usn_journal_rs::mft::MftIter| -> Vec<_> {
+        iter.filter_map(Result::ok)
+            .take(PREFIX)
+            .map(|entry| entry.fid)
+            .collect::<Vec<_>>()
+    };
+
+    let via_accessor = collect_prefix(volume.mft().try_iter().expect("accessor mft try_iter"));
+    let via_constructor =
+        collect_prefix(Mft::new(&volume).try_iter().expect("constructor mft try_iter"));
+
+    assert!(!via_accessor.is_empty(), "MFT enumeration yielded no entries");
+    assert_eq!(
+        via_accessor, via_constructor,
+        "volume.mft() must enumerate the same records as Mft::new"
+    );
+}
+
+#[test]
+fn raw_mft_accessor_matches_constructor_geometry() {
+    let Some(volume) = open_test_volume("raw_mft_accessor_matches_constructor_geometry") else {
+        return;
+    };
+
+    let via_accessor = match volume.raw_mft() {
+        Ok(m) => m,
+        Err(UsnError::UnsupportedFilesystem(msg)) => {
+            eprintln!("raw_mft_accessor_matches_constructor_geometry: skipping (not NTFS: {msg})");
+            return;
+        }
+        Err(e) => panic!("volume.raw_mft() failed unexpectedly: {e}"),
+    };
+    let via_constructor = RawMft::new(&volume).expect("RawMft::new should succeed on NTFS");
+
+    // Cluster size and file-record size come straight from the boot sector,
+    // so they are fixed volume geometry and must match exactly.
+    assert_eq!(
+        via_accessor.cluster_size(),
+        via_constructor.cluster_size(),
+        "cluster_size must match between accessor and constructor"
+    );
+    assert_eq!(
+        via_accessor.file_record_size(),
+        via_constructor.file_record_size(),
+        "file_record_size must match between accessor and constructor"
+    );
+    assert!(
+        via_accessor.cluster_size() > 0 && via_accessor.file_record_size() > 0,
+        "raw MFT geometry values must be non-zero"
+    );
+}
+
+#[test]
+fn path_resolver_accessor_matches_constructor() {
+    let Some(volume) = open_test_volume("path_resolver_accessor_matches_constructor") else {
+        return;
+    };
+
+    let accessor_resolver = volume.path_resolver();
+    let constructor_resolver = PathResolver::new(&volume);
+
+    let mut compared = 0usize;
+    for entry in Mft::new(&volume)
+        .try_iter()
+        .expect("mft try_iter")
+        .filter_map(Result::ok)
+        .filter(|e| !e.file_name.is_empty())
+        .take(200)
+    {
+        let via_accessor = accessor_resolver.resolve_path(&entry);
+        let via_constructor = constructor_resolver.resolve_path(&entry);
+        assert_eq!(
+            via_accessor, via_constructor,
+            "accessor and constructor resolvers must agree for fid {}",
+            entry.fid
+        );
+        if via_accessor.is_some() {
+            compared += 1;
+        }
+    }
+
+    assert!(
+        compared > 0,
+        "expected at least one resolvable entry in the first 200 MFT records"
+    );
+}
+
+#[test]
+fn mft_high_usn_zero_yields_no_entries() {
+    let Some(volume) = open_test_volume("mft_high_usn_zero_yields_no_entries") else {
+        return;
+    };
+
+    // A HighUsn of 0 means "only records whose USN is <= 0". Real files always
+    // have a positive USN, so this must yield an empty enumeration. This also
+    // guards the fix that no longer seeds the enumeration cursor from low_usn:
+    // enumeration still starts at record 0 and filters purely by USN.
+    let options = MftIterOptions::builder()
+        .low_usn(Usn::new(0))
+        .high_usn(Usn::new(0))
+        .build();
+
+    let mut yielded = 0usize;
+    for result in volume.mft().try_iter_with_options(options).expect("try_iter") {
+        match result {
+            Ok(_) => yielded += 1,
+            Err(e) => panic!("unexpected error during bounded MFT enumeration: {e}"),
+        }
+        if yielded > 0 {
+            break;
+        }
+    }
+
+    assert_eq!(
+        yielded, 0,
+        "HighUsn=0 should filter out every real record, but {yielded} were returned"
+    );
+}
+
+#[test]
+fn mft_full_range_yields_many_entries() {
+    let Some(volume) = open_test_volume("mft_full_range_yields_many_entries") else {
+        return;
+    };
+
+    // Sanity check on the default (full) USN range: enumeration starting at
+    // record 0 must return a healthy number of records.
+    let count = volume
+        .mft()
+        .try_iter()
+        .expect("try_iter")
+        .filter_map(Result::ok)
+        .take(1_000)
+        .count();
+
+    assert!(
+        count >= 100,
+        "expected the full-range MFT scan to yield many records, got {count}"
+    );
+}


### PR DESCRIPTION
## Summary

A broad code-quality pass on the public API and internals, folding into the unreleased **0.5.0**. The goal is to make the crate more consistent, more ergonomic, more idiomatic, and far better tested — so it's easy to reach for when working with the Windows USN change journal and MFT.

**Breaking changes are included** (all in unreleased 0.5.0). See `CHANGELOG.md` for the full before/after migration notes.

54 files changed (+2,755 / −306), including 3 new files.

## 🐛 Bug fixes

- **MFT enumeration cursor** (`Mft::try_iter_with_options`): the enumeration was seeding its `StartFileReferenceNumber` from `low_usn` — leaking a USN value into the MFT record cursor. It now always starts at record 0 and filters purely by `low_usn`/`high_usn`, per the `FSCTL_ENUM_USN_DATA` contract. (Only affected non-zero `low_usn`.)
- **Journal read timeout unit**: the field was documented as "100-nanosecond units" but `READ_USN_JOURNAL_DATA.Timeout` is in **seconds**. The builder now takes a `std::time::Duration` (truncated to whole seconds) and the docs match.

## 💥 Breaking changes

- `UsnJournal::query(bool)` → `query()` (returns new `UsnError::JournalNotActive` when inactive) + `query_or_create()`.
- `PathResolver::resolve_path` now takes `&self` (interior mutability) — matches `RawMftPathResolver` and removes the need for `let mut resolver`.
- `JournalIterOptionsBuilder::timeout` now takes `Duration` instead of `u64`.
- `UsnError::InvalidMountPointError` → `InvalidMountPoint`.
- Removed `UsnEntry::get_reason_string()` (use `entry.reason` `Display`) and `Fid::from_u64` (use `Fid::new` / `Fid::from`).
- `UsnReason` empty `Display` is now `NONE` (was `UNKNOWN`); unknown bits render as hex — consistent with `FileAttributes`/`UsnSourceInfo`.

## ✨ New / ergonomic APIs

- `Volume` accessors: `journal()`, `mft()`, `raw_mft()`, `path_resolver()` — e.g. `volume.journal().try_iter()?`.
- Predicates: `UsnReason::{is_file_create, is_file_delete, is_rename, is_close, is_data_change}`, `FileAttributes::{is_directory, is_reparse_point, …}`, and the same attribute predicates on `UsnEntry`/`MftEntry`.
- `UsnReason::ALL` (full catch-all mask), `Usn::{ZERO, is_zero, saturating_add, checked_add}`.
- `Filetime::{UNIX_EPOCH, is_zero, to_unix_millis, from_unix_seconds}`.
- `Fid::from_parts(record, sequence)` + `LowerHex`/`UpperHex` impls.
- `Display` for `RawMftEntry` (parity with `UsnEntry`/`MftEntry`) and `UsnJournalData` (compact logging).
- Expanded `prelude` (entry types + option builders).

## 🧹 Idiomatic internals

- Unified the three bitflags `Display` impls into one `write_flag_names` helper.
- Named `attr_header_flags` constants replace magic numbers in raw-`$MFT` entry construction; shared `parse_record_at` helper de-duplicates the record readers.

## 📚 Docs

- Reconciled `CHANGELOG.md` and `README.md` with the actual shipped API (several stale entries fixed; corrected "Divan" → Criterion).
- Added runnable, compile-checked doc examples on key methods.

## ✅ Tests & verification

- Unit tests **144 → 249** (+105), integration **10 → 28**, doctests **4 → 7**. New coverage across every parser (boot/record/extent/data-run/USA-fixup/attribute), the USN buffer walker, path/history reconstruction, chunk planning, the parallel executor helpers, and the new public APIs.
- `cargo build`, `cargo clippy --all-targets` (strict lints), the full test suite, and `cargo package` all pass. An independent code review found no issues.

## Notes

- Integration tests honor `USN_TEST_DRIVE` (default `C`) and skip gracefully when not elevated or the volume is unsuitable.