### PR TITLE
Fix raw MFT review findings

### DIFF
--- a/src/raw_mft/bootstrap/discovery.rs
+++ b/src/raw_mft/bootstrap/discovery.rs
@@ -39,6 +39,7 @@ pub(super) struct MftBootstrap {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StreamExtent {
     lowest_vcn: u64,
+    record_number: u64,
     attribute_id: u16,
     runs: Vec<DataRun>,
 }
@@ -129,14 +130,14 @@ fn capture_stream_attributes(
         let unnamed = !attr.has_name();
 
         if type_id == NtfsAttributeType::Data as u32 && unnamed && attr.is_non_resident() {
-            if let Some(extent) = decode_nonresident_extent(attr, "$MFT $DATA") {
+            if let Some(extent) = decode_nonresident_extent(attr, record.number, "$MFT $DATA") {
                 insert_extent(&mut streams.data_extents, extent);
             }
         } else if type_id == NtfsAttributeType::Bitmap as u32 && unnamed && attr.is_non_resident() {
             if let Some(header) = attr.nonresident_header() {
                 streams.bitmap_size = streams.bitmap_size.max(header.data_size);
             }
-            if let Some(extent) = decode_nonresident_extent(attr, "$MFT $BITMAP") {
+            if let Some(extent) = decode_nonresident_extent(attr, record.number, "$MFT $BITMAP") {
                 insert_extent(&mut streams.bitmap_extents, extent);
             }
         } else if capture_attribute_list
@@ -150,7 +151,9 @@ fn capture_stream_attributes(
 
 fn insert_extent(extents: &mut Vec<StreamExtent>, extent: StreamExtent) {
     if !extents.iter().any(|existing| {
-        existing.lowest_vcn == extent.lowest_vcn && existing.attribute_id == extent.attribute_id
+        existing.lowest_vcn == extent.lowest_vcn
+            && existing.record_number == extent.record_number
+            && existing.attribute_id == extent.attribute_id
     }) {
         extents.push(extent);
     }
@@ -259,7 +262,9 @@ fn target_is_loaded(streams: &MftStreamRuns, target: StreamTarget) -> bool {
         &streams.bitmap_extents
     };
     extents.iter().any(|extent| {
-        extent.lowest_vcn == target.lowest_vcn && extent.attribute_id == target.attribute_id
+        extent.lowest_vcn == target.lowest_vcn
+            && extent.record_number == target.record_number
+            && extent.attribute_id == target.attribute_id
     })
 }
 
@@ -309,7 +314,12 @@ fn assemble_runs(
         if extent.lowest_vcn > expected_vcn && stop_at_gap {
             return Ok((runs, false));
         }
-        if extent.lowest_vcn != expected_vcn {
+        if extent.lowest_vcn < expected_vcn {
+            return Err(UsnError::InvalidDataRun(
+                "non-resident stream extents overlap in VCN space",
+            ));
+        }
+        if extent.lowest_vcn > expected_vcn {
             return Ok((runs, false));
         }
         let clusters = extent.runs.iter().try_fold(0u64, |total, run| {
@@ -330,6 +340,7 @@ fn assemble_runs(
 
 fn decode_nonresident_extent(
     attr: &NtfsAttribute<'_>,
+    record_number: u64,
     label: &'static str,
 ) -> Option<StreamExtent> {
     let header = attr.nonresident_header()?;
@@ -338,6 +349,7 @@ fn decode_nonresident_extent(
     }
     decode_nonresident_runs(attr, label).map(|runs| StreamExtent {
         lowest_vcn: header.lowest_vcn as u64,
+        record_number,
         attribute_id: attr.header.id,
         runs,
     })
@@ -456,6 +468,7 @@ mod tests {
         let extents = vec![
             StreamExtent {
                 lowest_vcn: 3,
+                record_number: 11,
                 attribute_id: 2,
                 runs: vec![DataRun::Data {
                     lcn: 200,
@@ -464,6 +477,7 @@ mod tests {
             },
             StreamExtent {
                 lowest_vcn: 0,
+                record_number: 0,
                 attribute_id: 1,
                 runs: vec![DataRun::Data {
                     lcn: 100,
@@ -492,6 +506,7 @@ mod tests {
         let extents = vec![
             StreamExtent {
                 lowest_vcn: 0,
+                record_number: 0,
                 attribute_id: 1,
                 runs: vec![DataRun::Data {
                     lcn: 100,
@@ -500,6 +515,7 @@ mod tests {
             },
             StreamExtent {
                 lowest_vcn: 3,
+                record_number: 11,
                 attribute_id: 2,
                 runs: vec![DataRun::Data {
                     lcn: 200,
@@ -516,5 +532,69 @@ mod tests {
                 clusters: 2,
             }]
         );
+    }
+
+    #[test]
+    fn rejects_stream_extent_vcn_overlaps_even_for_prefix_assembly() {
+        let extents = vec![
+            StreamExtent {
+                lowest_vcn: 0,
+                record_number: 0,
+                attribute_id: 1,
+                runs: vec![DataRun::Data {
+                    lcn: 100,
+                    clusters: 3,
+                }],
+            },
+            StreamExtent {
+                lowest_vcn: 2,
+                record_number: 11,
+                attribute_id: 2,
+                runs: vec![DataRun::Data {
+                    lcn: 200,
+                    clusters: 1,
+                }],
+            },
+        ];
+
+        assert!(assemble_stream_runs(&extents).is_err());
+        assert!(assemble_contiguous_prefix(&extents).is_err());
+    }
+
+    #[test]
+    fn target_loadedness_includes_source_record_number() {
+        let streams = MftStreamRuns {
+            data_extents: vec![StreamExtent {
+                lowest_vcn: 4,
+                record_number: 10,
+                attribute_id: 2,
+                runs: vec![DataRun::Data {
+                    lcn: 100,
+                    clusters: 1,
+                }],
+            }],
+            bitmap_extents: Vec::new(),
+            bitmap_size: 0,
+            attribute_list: None,
+        };
+
+        assert!(target_is_loaded(
+            &streams,
+            StreamTarget {
+                type_id: NtfsAttributeType::Data as u32,
+                lowest_vcn: 4,
+                record_number: 10,
+                attribute_id: 2,
+            }
+        ));
+        assert!(!target_is_loaded(
+            &streams,
+            StreamTarget {
+                type_id: NtfsAttributeType::Data as u32,
+                lowest_vcn: 4,
+                record_number: 11,
+                attribute_id: 2,
+            }
+        ));
     }
 }

--- a/src/raw_mft/bootstrap/discovery.rs
+++ b/src/raw_mft/bootstrap/discovery.rs
@@ -1,6 +1,7 @@
 //! Stream-discovery helpers for raw-MFT constructor bootstrapping.
 
 use std::{
+    collections::HashSet,
     io::{Read, Seek, SeekFrom},
     sync::Arc,
 };
@@ -10,9 +11,13 @@ use log::warn;
 use crate::{
     errors::UsnError,
     raw_mft::{
+        entry_build::AttributeListInfo,
         io::VolumeReader,
         layout::{
-            attribute::{NtfsAttribute, NtfsAttributeType, for_each_attribute},
+            attribute::{
+                NtfsAttribute, NtfsAttributeType, for_each_attr_list_entry_header,
+                for_each_attribute,
+            },
             boot::BootSector,
             data_run::{DataRun, decode_runs},
             extent::ExtentMap,
@@ -31,10 +36,26 @@ pub(super) struct MftBootstrap {
     pub(super) bitmap: Arc<[u8]>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StreamExtent {
+    lowest_vcn: u64,
+    attribute_id: u16,
+    runs: Vec<DataRun>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct StreamTarget {
+    type_id: u32,
+    lowest_vcn: u64,
+    record_number: u64,
+    attribute_id: u16,
+}
+
 struct MftStreamRuns {
-    data_runs: Option<Vec<DataRun>>,
-    bitmap_runs: Option<Vec<DataRun>>,
+    data_extents: Vec<StreamExtent>,
+    bitmap_extents: Vec<StreamExtent>,
     bitmap_size: u64,
+    attribute_list: Option<AttributeListInfo>,
 }
 
 /// Read FILE record 0, discover its stream runs, and materialize the shared
@@ -45,15 +66,17 @@ pub(super) fn bootstrap_mft_state(
 ) -> Result<MftBootstrap, UsnError> {
     let mut reader = VolumeReader::new(volume.handle, boot.bytes_per_sector as u64)?;
     let mut record0 = read_mft_record_zero(&mut reader, boot)?;
-    let streams = {
+    let mut streams = {
         let record =
             FileRecord::parse(MFT_RECORD_NUMBER, Some(boot.mft_byte_offset), &mut record0)?;
         discover_mft_stream_runs(&record)
     };
+    load_extension_stream_extents(&mut reader, boot, &mut streams)?;
 
-    let data_runs = streams
-        .data_runs
-        .ok_or(UsnError::MftAttributeMissing("$MFT $DATA"))?;
+    if streams.data_extents.is_empty() {
+        return Err(UsnError::MftAttributeMissing("$MFT $DATA"));
+    }
+    let data_runs = assemble_stream_runs(&streams.data_extents)?;
     let extent_map = Arc::new(ExtentMap::from_runs(
         &data_runs,
         boot.cluster_size,
@@ -62,7 +85,9 @@ pub(super) fn bootstrap_mft_state(
     let bitmap = load_mft_bitmap(
         &mut reader,
         boot.cluster_size,
-        streams.bitmap_runs,
+        (!streams.bitmap_extents.is_empty())
+            .then(|| assemble_stream_runs(&streams.bitmap_extents))
+            .transpose()?,
         streams.bitmap_size,
     )?;
 
@@ -82,30 +107,240 @@ fn read_mft_record_zero(reader: &mut VolumeReader, boot: &BootSector) -> Result<
 /// Walk FILE record 0 and collect the decoded runlists for `$MFT::$DATA`
 /// and `$MFT::$BITMAP`.
 fn discover_mft_stream_runs(record: &FileRecord<'_>) -> MftStreamRuns {
-    let mut data_runs = None;
-    let mut bitmap_runs = None;
-    let mut bitmap_size = 0u64;
+    let mut streams = MftStreamRuns {
+        data_extents: Vec::new(),
+        bitmap_extents: Vec::new(),
+        bitmap_size: 0,
+        attribute_list: None,
+    };
+    capture_stream_attributes(record, &mut streams, true);
+    streams
+}
 
+/// Capture `$MFT::$DATA` and `$MFT::$BITMAP` extents from one fixed-up record.
+fn capture_stream_attributes(
+    record: &FileRecord<'_>,
+    streams: &mut MftStreamRuns,
+    capture_attribute_list: bool,
+) {
     let (attrs_off, used) = record.attrs_range();
     for_each_attribute(record.data, attrs_off, used, |attr| {
         let type_id = attr.type_id();
         let unnamed = !attr.has_name();
 
         if type_id == NtfsAttributeType::Data as u32 && unnamed && attr.is_non_resident() {
-            data_runs = decode_nonresident_runs(attr, "$MFT $DATA");
-        } else if type_id == NtfsAttributeType::Bitmap as u32 && attr.is_non_resident() {
-            if let Some(header) = attr.nonresident_header() {
-                bitmap_size = header.data_size;
+            if let Some(extent) = decode_nonresident_extent(attr, "$MFT $DATA") {
+                insert_extent(&mut streams.data_extents, extent);
             }
-            bitmap_runs = decode_nonresident_runs(attr, "$MFT $BITMAP");
+        } else if type_id == NtfsAttributeType::Bitmap as u32 && unnamed && attr.is_non_resident() {
+            if let Some(header) = attr.nonresident_header() {
+                streams.bitmap_size = streams.bitmap_size.max(header.data_size);
+            }
+            if let Some(extent) = decode_nonresident_extent(attr, "$MFT $BITMAP") {
+                insert_extent(&mut streams.bitmap_extents, extent);
+            }
+        } else if capture_attribute_list
+            && type_id == NtfsAttributeType::AttributeList as u32
+            && streams.attribute_list.is_none()
+        {
+            streams.attribute_list = capture_attribute_list_info(attr);
+        }
+    });
+}
+
+fn insert_extent(extents: &mut Vec<StreamExtent>, extent: StreamExtent) {
+    if !extents.iter().any(|existing| {
+        existing.lowest_vcn == extent.lowest_vcn && existing.attribute_id == extent.attribute_id
+    }) {
+        extents.push(extent);
+    }
+}
+
+fn capture_attribute_list_info(attr: &NtfsAttribute<'_>) -> Option<AttributeListInfo> {
+    if attr.is_non_resident() {
+        let header = attr.nonresident_header()?;
+        let start = header.data_runs_offset as usize;
+        Some(AttributeListInfo::NonResident {
+            runs_data: attr.data().get(start..)?.to_vec(),
+            data_size: header.data_size,
+        })
+    } else {
+        attr.resident_value()
+            .map(|value| AttributeListInfo::Resident(value.to_vec()))
+    }
+}
+
+/// Load stream extents referenced by record 0's `$ATTRIBUTE_LIST`.
+///
+/// This is iterative because a newly discovered `$DATA` extent can make a
+/// later extension record addressable through the growing partial extent map.
+fn load_extension_stream_extents(
+    reader: &mut VolumeReader,
+    boot: &BootSector,
+    streams: &mut MftStreamRuns,
+) -> Result<(), UsnError> {
+    let Some(attribute_list) = streams.attribute_list.take() else {
+        return Ok(());
+    };
+    let data = materialize_attribute_list(reader, boot.cluster_size, attribute_list)?;
+    let mut targets = Vec::new();
+    let mut seen = HashSet::new();
+    for_each_attr_list_entry_header(&data, |header| {
+        let type_id = header.type_id;
+        let is_stream = (type_id == NtfsAttributeType::Data as u32
+            || type_id == NtfsAttributeType::Bitmap as u32)
+            && header.attribute_name_length == 0;
+        if !is_stream || header.lowest_vcn < 0 {
+            return;
+        }
+        let target = StreamTarget {
+            type_id,
+            lowest_vcn: header.lowest_vcn as u64,
+            record_number: header.file_reference & 0x0000_FFFF_FFFF_FFFF,
+            attribute_id: header.attribute_id,
+        };
+        if seen.insert(target) {
+            targets.push(target);
         }
     });
 
-    MftStreamRuns {
-        data_runs,
-        bitmap_runs,
-        bitmap_size,
+    loop {
+        let unresolved: Vec<_> = targets
+            .iter()
+            .copied()
+            .filter(|target| !target_is_loaded(streams, *target))
+            .collect();
+        if unresolved.is_empty() {
+            return Ok(());
+        }
+
+        let prefix_runs = assemble_contiguous_prefix(&streams.data_extents)?;
+        if prefix_runs.is_empty() {
+            return Err(UsnError::MftAttributeMissing("$MFT $DATA VCN 0 extent"));
+        }
+        let partial_map =
+            ExtentMap::from_runs(&prefix_runs, boot.cluster_size, boot.file_record_size);
+        let before = streams.data_extents.len() + streams.bitmap_extents.len();
+        let mut loaded_records = HashSet::new();
+
+        for target in unresolved {
+            if target.record_number == MFT_RECORD_NUMBER
+                || !loaded_records.insert(target.record_number)
+            {
+                continue;
+            }
+            let offset = match partial_map.record_offset(target.record_number) {
+                Ok(Some(offset)) => offset,
+                Ok(None) | Err(_) => continue,
+            };
+            let buf = reader
+                .borrow_at(offset, boot.file_record_size as usize)
+                .map_err(io_err)?;
+            if !FileRecord::is_valid(buf) {
+                continue;
+            }
+            let record = FileRecord::parse(target.record_number, Some(offset), buf)?;
+            capture_stream_attributes(&record, streams, false);
+        }
+
+        let after = streams.data_extents.len() + streams.bitmap_extents.len();
+        if after == before {
+            return Err(UsnError::MftAttributeMissing(
+                "$MFT stream extension referenced by $ATTRIBUTE_LIST",
+            ));
+        }
     }
+}
+
+fn target_is_loaded(streams: &MftStreamRuns, target: StreamTarget) -> bool {
+    let extents = if target.type_id == NtfsAttributeType::Data as u32 {
+        &streams.data_extents
+    } else {
+        &streams.bitmap_extents
+    };
+    extents.iter().any(|extent| {
+        extent.lowest_vcn == target.lowest_vcn && extent.attribute_id == target.attribute_id
+    })
+}
+
+fn materialize_attribute_list(
+    reader: &mut VolumeReader,
+    cluster_size: u64,
+    attribute_list: AttributeListInfo,
+) -> Result<Vec<u8>, UsnError> {
+    match attribute_list {
+        AttributeListInfo::Resident(data) => Ok(data),
+        AttributeListInfo::NonResident {
+            runs_data,
+            data_size,
+        } => {
+            let (runs, _) = decode_runs(&runs_data)?;
+            read_nonresident(reader, &runs, cluster_size, data_size)
+        }
+    }
+}
+
+/// Assemble extents in lowest-VCN order. Mapping pairs in each attribute
+/// extent are relative to that extent's `lowest_vcn`, not implicitly VCN zero.
+fn assemble_stream_runs(extents: &[StreamExtent]) -> Result<Vec<DataRun>, UsnError> {
+    let (runs, complete) = assemble_runs(extents, false)?;
+    if !complete {
+        return Err(UsnError::InvalidDataRun(
+            "non-resident stream extents contain a VCN gap or overlap",
+        ));
+    }
+    Ok(runs)
+}
+
+fn assemble_contiguous_prefix(extents: &[StreamExtent]) -> Result<Vec<DataRun>, UsnError> {
+    assemble_runs(extents, true).map(|(runs, _)| runs)
+}
+
+fn assemble_runs(
+    extents: &[StreamExtent],
+    stop_at_gap: bool,
+) -> Result<(Vec<DataRun>, bool), UsnError> {
+    let mut ordered: Vec<_> = extents.iter().collect();
+    ordered.sort_by_key(|extent| extent.lowest_vcn);
+    let mut expected_vcn = 0u64;
+    let mut runs = Vec::new();
+
+    for extent in ordered {
+        if extent.lowest_vcn > expected_vcn && stop_at_gap {
+            return Ok((runs, false));
+        }
+        if extent.lowest_vcn != expected_vcn {
+            return Ok((runs, false));
+        }
+        let clusters = extent.runs.iter().try_fold(0u64, |total, run| {
+            let count = match run {
+                DataRun::Data { clusters, .. } | DataRun::Sparse { clusters } => *clusters,
+            };
+            total
+                .checked_add(count)
+                .ok_or(UsnError::InvalidDataRun("stream VCN length overflow"))
+        })?;
+        expected_vcn = expected_vcn
+            .checked_add(clusters)
+            .ok_or(UsnError::InvalidDataRun("stream VCN end overflow"))?;
+        runs.extend_from_slice(&extent.runs);
+    }
+    Ok((runs, true))
+}
+
+fn decode_nonresident_extent(
+    attr: &NtfsAttribute<'_>,
+    label: &'static str,
+) -> Option<StreamExtent> {
+    let header = attr.nonresident_header()?;
+    if header.lowest_vcn < 0 {
+        return None;
+    }
+    decode_nonresident_runs(attr, label).map(|runs| StreamExtent {
+        lowest_vcn: header.lowest_vcn as u64,
+        attribute_id: attr.header.id,
+        runs,
+    })
 }
 
 /// Load the `$MFT::$BITMAP` stream when it exists.
@@ -214,5 +449,72 @@ mod tests {
         let buf = build_nonresident_attr(header_size as u16, &[0x21, 0x05]);
         let attr = NtfsAttribute::new(&buf).expect("attr");
         assert!(decode_nonresident_runs(&attr, "$TEST").is_none());
+    }
+
+    #[test]
+    fn assembles_stream_extents_in_lowest_vcn_order() {
+        let extents = vec![
+            StreamExtent {
+                lowest_vcn: 3,
+                attribute_id: 2,
+                runs: vec![DataRun::Data {
+                    lcn: 200,
+                    clusters: 2,
+                }],
+            },
+            StreamExtent {
+                lowest_vcn: 0,
+                attribute_id: 1,
+                runs: vec![DataRun::Data {
+                    lcn: 100,
+                    clusters: 3,
+                }],
+            },
+        ];
+
+        assert_eq!(
+            assemble_stream_runs(&extents).expect("contiguous extents"),
+            vec![
+                DataRun::Data {
+                    lcn: 100,
+                    clusters: 3,
+                },
+                DataRun::Data {
+                    lcn: 200,
+                    clusters: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_stream_extent_vcn_gaps() {
+        let extents = vec![
+            StreamExtent {
+                lowest_vcn: 0,
+                attribute_id: 1,
+                runs: vec![DataRun::Data {
+                    lcn: 100,
+                    clusters: 2,
+                }],
+            },
+            StreamExtent {
+                lowest_vcn: 3,
+                attribute_id: 2,
+                runs: vec![DataRun::Data {
+                    lcn: 200,
+                    clusters: 1,
+                }],
+            },
+        ];
+
+        assert!(assemble_stream_runs(&extents).is_err());
+        assert_eq!(
+            assemble_contiguous_prefix(&extents).expect("usable prefix"),
+            vec![DataRun::Data {
+                lcn: 100,
+                clusters: 2,
+            }]
+        );
     }
 }

--- a/src/raw_mft/layout/attribute/iter.rs
+++ b/src/raw_mft/layout/attribute/iter.rs
@@ -21,6 +21,19 @@ pub(crate) fn for_each_attr_list_entry<F>(data: &[u8], mut f: F)
 where
     F: FnMut(u32, u64),
 {
+    for_each_attr_list_entry_header(data, |header| {
+        f(header.type_id, header.file_reference);
+    });
+}
+
+/// Call `f` with the complete header of each valid `$ATTRIBUTE_LIST` entry.
+///
+/// Bootstrap code needs the lowest VCN and attribute instance identifier in
+/// addition to the record reference, so keep that detail in one bounded parser.
+pub(crate) fn for_each_attr_list_entry_header<F>(data: &[u8], mut f: F)
+where
+    F: FnMut(AttributeListEntryHeader),
+{
     let mut offset = 0usize;
     while offset + ATTR_LIST_ENTRY_MIN_SIZE <= data.len() {
         let bytes = &data[offset..offset + ATTR_LIST_ENTRY_MIN_SIZE];
@@ -32,11 +45,13 @@ where
         if len < ATTR_LIST_ENTRY_MIN_SIZE {
             break;
         }
-        f(h.type_id, h.file_reference);
-        offset = match offset.checked_add(len) {
-            Some(o) => o,
+        let next = match offset.checked_add(len) {
+            Some(o) if o <= data.len() => o,
             None => break,
+            _ => break,
         };
+        f(h);
+        offset = next;
     }
 }
 

--- a/src/raw_mft/layout/attribute/mod.rs
+++ b/src/raw_mft/layout/attribute/mod.rs
@@ -15,5 +15,7 @@ pub(crate) use headers::{
     NtfsNonResidentAttributeHeader, NtfsResidentAttributeHeader, NtfsStandardInformation,
     attr_header_flags, file_attr_flags,
 };
-pub(crate) use iter::{for_each_attr_list_entry, for_each_attribute};
+pub(crate) use iter::{
+    for_each_attr_list_entry, for_each_attr_list_entry_header, for_each_attribute,
+};
 pub(crate) use view::{NtfsAttribute, osstring_from_utf16le};

--- a/src/raw_mft/path_resolver.rs
+++ b/src/raw_mft/path_resolver.rs
@@ -1,6 +1,9 @@
 //! Snapshot path resolver for entries produced by a raw `$MFT` scan.
 
-use std::{cell::RefCell, path::PathBuf};
+use std::{
+    cell::RefCell,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     UsnResult,
@@ -61,6 +64,7 @@ impl<'a> RawMftPathResolver<'a> {
     pub fn resolve_path(&self, entry: &RawMftEntry) -> Option<PathBuf> {
         self.in_memory_tree
             .resolve_with_optional_drive(entry.file_reference, self.volume.drive_letter())
+            .map(|path| prefix_mount_point(self.volume, &path))
             .or_else(|| {
                 if self.live_fallback {
                     resolve_live_path(
@@ -74,5 +78,41 @@ impl<'a> RawMftPathResolver<'a> {
                     None
                 }
             })
+    }
+}
+
+/// Snapshot tree paths already include drive-letter roots. For volumes opened
+/// through a mount point the tree returns a relative path, so attach that
+/// source prefix before exposing the result.
+fn prefix_mount_point(volume: &Volume, path: &Path) -> PathBuf {
+    volume
+        .mount_point()
+        .map_or_else(|| path.to_path_buf(), |mount_point| mount_point.join(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::volume::VolumeSource;
+    use windows::Win32::Foundation::HANDLE;
+
+    #[test]
+    fn snapshot_path_is_prefixed_for_mount_point_volumes() {
+        let volume = Volume::mock(
+            HANDLE(std::ptr::null_mut()),
+            VolumeSource::MountPoint(PathBuf::from(r"C:\mnt\data")),
+        );
+
+        assert_eq!(
+            prefix_mount_point(&volume, Path::new(r"dir\file.txt")),
+            PathBuf::from(r"C:\mnt\data\dir\file.txt")
+        );
+    }
+
+    #[test]
+    fn drive_letter_snapshot_path_is_unchanged() {
+        let volume = Volume::mock(HANDLE(std::ptr::null_mut()), VolumeSource::DriveLetter('C'));
+        let path = Path::new(r"C:\dir\file.txt");
+        assert_eq!(prefix_mount_point(&volume, path), path);
     }
 }

--- a/src/usn_record.rs
+++ b/src/usn_record.rs
@@ -217,6 +217,10 @@ pub(crate) fn find_next_record<'a>(
 
     let min_record_len = size_of::<USN_RECORD_COMMON_HEADER>();
     if bytes_read - offset_usize < min_record_len {
+        // The remaining bytes cannot contain a record boundary that we can
+        // trust. Consume this kernel buffer so the iterator does not return
+        // the same error forever on subsequent calls to `next()`.
+        *offset = bytes_read as u32;
         return Err(UsnError::TruncatedRecord {
             offset: offset_usize as u64,
             needed: min_record_len,
@@ -234,6 +238,7 @@ pub(crate) fn find_next_record<'a>(
 
     let record_len = header.RecordLength as usize;
     if record_len < min_record_len {
+        *offset = bytes_read as u32;
         return Err(UsnError::InvalidRecordLength {
             offset: offset_usize as u64,
             length: header.RecordLength,
@@ -241,12 +246,24 @@ pub(crate) fn find_next_record<'a>(
         });
     }
     if record_len > bytes_read - offset_usize {
+        *offset = bytes_read as u32;
         return Err(UsnError::TruncatedRecord {
             offset: offset_usize as u64,
             needed: record_len,
             got: bytes_read - offset_usize,
         });
     }
+
+    // From this point on the record boundary is trustworthy. Advance before
+    // performing version-specific validation so a malformed item is yielded
+    // once instead of trapping Journal/MFT iterators on the same offset.
+    let next_offset = offset_usize
+        .checked_add(record_len)
+        .ok_or(UsnError::InvalidRecord {
+            offset: offset_usize as u64,
+            reason: "next record offset overflowed",
+        })?;
+    *offset = next_offset as u32;
 
     let record = match header.MajorVersion {
         2 => {
@@ -308,14 +325,6 @@ pub(crate) fn find_next_record<'a>(
         });
     }
 
-    let next_offset = offset_usize
-        .checked_add(record_len)
-        .ok_or(UsnError::InvalidRecord {
-            offset: offset_usize as u64,
-            reason: "next record offset overflowed",
-        })?;
-
-    *offset = next_offset as u32;
     Ok(Some(record))
 }
 
@@ -371,6 +380,7 @@ mod tests {
                 got: 2
             } if needed == size_of::<USN_RECORD_COMMON_HEADER>()
         ));
+        assert_eq!(offset, 2, "unusable buffer tail must be consumed");
     }
 
     #[test]
@@ -389,6 +399,11 @@ mod tests {
                 reason: "record length is smaller than header"
             } if length == (header_len - 1) as u32
         ));
+        assert_eq!(
+            offset,
+            buf.len() as u32,
+            "invalid boundary must consume buffer"
+        );
     }
 
     #[test]
@@ -406,6 +421,11 @@ mod tests {
                 major_version: 99
             }
         ));
+        assert_eq!(
+            offset,
+            buf.len() as u32,
+            "unsupported record must be consumed"
+        );
     }
 
     /// Build a `USN_RECORD_V2` buffer with the given fields and file name.
@@ -544,7 +564,11 @@ mod tests {
         assert_eq!(second.fid(), Fid::new(0x11));
 
         assert_eq!(offset, total);
-        assert!(find_next_record(&buf, total, &mut offset).unwrap().is_none());
+        assert!(
+            find_next_record(&buf, total, &mut offset)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -574,6 +598,11 @@ mod tests {
         let mut offset = 0u32;
         let err = find_next_record(&buf, buf.len() as u32, &mut offset).unwrap_err();
         assert!(matches!(err, UsnError::MisalignedRecord { offset: 0, .. }));
+        assert_eq!(
+            offset,
+            buf.len() as u32,
+            "malformed record must be consumed"
+        );
     }
 
     #[test]
@@ -592,6 +621,29 @@ mod tests {
                 reason: "file name range exceeds record length"
             }
         ));
+        assert_eq!(
+            offset,
+            buf.len() as u32,
+            "malformed record must be consumed"
+        );
+    }
+
+    #[test]
+    fn malformed_record_does_not_block_following_record() {
+        let mut first = build_v2_record(1, 0x10, 0x5, 0, 0, "bad");
+        let len_off = std::mem::offset_of!(USN_RECORD_V2, FileNameLength);
+        first[len_off..len_off + 2].copy_from_slice(&3u16.to_le_bytes());
+        let first_len = first.len() as u32;
+        first.extend(build_v2_record(2, 0x11, 0x5, 0, 0, "good"));
+
+        let mut offset = 0u32;
+        assert!(find_next_record(&first, first.len() as u32, &mut offset).is_err());
+        assert_eq!(offset, first_len);
+
+        let second = find_next_record(&first, first.len() as u32, &mut offset)
+            .expect("second parse")
+            .expect("second record");
+        assert_eq!(second.usn(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- assemble fragmented `$MFT::$DATA` and `$MFT::$BITMAP` extents by `lowest_vcn`
- follow record 0's `$ATTRIBUTE_LIST` to load stream extents stored in extension records
- consume malformed USN records so journal and MFT iterators continue instead of repeating the same error
- preserve mount-point prefixes in raw-MFT snapshot paths
- add regression tests for extent ordering and gaps, iterator progress, and mount-point paths

## Root cause

Bootstrap previously retained only one inline runlist and treated it as starting at VCN 0. The shared USN parser advanced its cursor only after all validation succeeded, and snapshot path construction only handled drive-letter roots.

## Validation

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- rustfmt checks on modified files
- `git diff --check`
